### PR TITLE
[RUNE-16] Story: Bridge wcwidth/wcswidth (baseline)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  SWIFT_VERSION: '6.1'
+  SWIFT_VERSION: '6.2'
 
 jobs:
   # Main build and test matrix across platforms

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Setup Swift
       uses: SwiftyLab/setup-swift@latest
       with:
-        swift-version: '6.1'
+        swift-version: '6.2'
         
     - name: Cache Swift Package Manager
       uses: actions/cache@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Swift
       uses: SwiftyLab/setup-swift@latest
       with:
-        swift-version: '6.1'
+        swift-version: '6.2'
 
     - name: Quick Build Check
       run: swift build

--- a/Sources/RuneANSI/StyledTextExample.swift
+++ b/Sources/RuneANSI/StyledTextExample.swift
@@ -34,7 +34,7 @@ public enum StyledTextExample {
 
     /// Demonstrates merging adjacent spans with identical attributes
     public static func mergingSpans() {
-        let converter = ANSISpanConverter()
+        _ = ANSISpanConverter()
 
         // Create styled text with adjacent spans that have the same attributes
         let redBold = TextAttributes(color: .red, bold: true)
@@ -61,7 +61,7 @@ public enum StyledTextExample {
 
     /// Demonstrates splitting styled text at column boundaries
     public static func splittingText() {
-        let converter = ANSISpanConverter()
+        _ = ANSISpanConverter()
 
         // Create styled text with multiple spans
         let styledText = StyledText(spans: [

--- a/Sources/RuneANSI/StyledTextExample.swift
+++ b/Sources/RuneANSI/StyledTextExample.swift
@@ -6,81 +6,80 @@
 import Foundation
 
 /// Example demonstrating styled text spans usage
-public struct StyledTextExample {
-    
+public enum StyledTextExample {
     /// Demonstrates basic conversion between ANSI tokens and styled text spans
     public static func basicConversion() {
         let tokenizer = ANSITokenizer()
         let converter = ANSISpanConverter()
-        
+
         // Parse ANSI-formatted text
         let input = "\u{001B}[1;31mError:\u{001B}[0m \u{001B}[33mWarning message\u{001B}[0m"
         let tokens = tokenizer.tokenize(input)
-        
+
         // Convert to styled text spans
         let styledText = converter.tokensToStyledText(tokens)
-        
+
         print("Original: \(input)")
         print("Spans:")
         for (index, span) in styledText.spans.enumerated() {
             print("  \(index): '\(span.text)' - \(span.attributes)")
         }
-        
+
         // Convert back to ANSI
         let outputTokens = converter.styledTextToTokens(styledText)
         let output = tokenizer.encode(outputTokens)
         print("Round-trip: \(output)")
         print("Identical: \(input == output)")
     }
-    
+
     /// Demonstrates merging adjacent spans with identical attributes
     public static func mergingSpans() {
         let converter = ANSISpanConverter()
-        
+
         // Create styled text with adjacent spans that have the same attributes
         let redBold = TextAttributes(color: .red, bold: true)
         let spans = [
             TextSpan(text: "Hello ", attributes: redBold),
             TextSpan(text: "beautiful ", attributes: redBold),
-            TextSpan(text: "world", attributes: redBold)
+            TextSpan(text: "world", attributes: redBold),
         ]
         let styledText = StyledText(spans: spans)
-        
+
         print("Before merging: \(styledText.spans.count) spans")
         for span in styledText.spans {
             print("  '\(span.text)'")
         }
-        
+
         // Merge adjacent spans
         let merged = styledText.mergingAdjacentSpans()
-        
+
         print("After merging: \(merged.spans.count) spans")
         for span in merged.spans {
             print("  '\(span.text)'")
         }
     }
-    
+
     /// Demonstrates splitting styled text at column boundaries
     public static func splittingText() {
         let converter = ANSISpanConverter()
-        
+
         // Create styled text with multiple spans
         let styledText = StyledText(spans: [
             TextSpan(text: "Hello ", attributes: TextAttributes(color: .red)),
             TextSpan(text: "beautiful ", attributes: TextAttributes(bold: true)),
-            TextSpan(text: "world!", attributes: TextAttributes(color: .blue))
+            TextSpan(text: "world!", attributes: TextAttributes(color: .blue)),
         ])
-        
+
         print("Original text: '\(styledText.plainText)'")
         print("Length: \(styledText.length)")
-        
+
         // Split at column 10
         let (left, right) = styledText.split(at: 10)
-        
+
         print("Split at column 10:")
         print("  Left: '\(left.plainText)' (\(left.spans.count) spans)")
         print("  Right: '\(right.plainText)' (\(right.spans.count) spans)")
-        
+
         // Demonstrate that attributes are preserved
         for (index, span) in left.spans.enumerated() {
             print("    Left span \(index): '\(span.text)' - \(span.attributes)")
@@ -89,40 +88,40 @@ public struct StyledTextExample {
             print("    Right span \(index): '\(span.text)' - \(span.attributes)")
         }
     }
-    
+
     /// Demonstrates working with complex color formats
     public static func complexColors() {
         let converter = ANSISpanConverter()
-        
+
         // Create spans with different color formats
         let spans = [
             TextSpan(text: "Basic red ", attributes: TextAttributes(color: .red)),
             TextSpan(text: "256-color ", attributes: TextAttributes(color: .color256(196))),
-            TextSpan(text: "RGB orange", attributes: TextAttributes(color: .rgb(255, 165, 0)))
+            TextSpan(text: "RGB orange", attributes: TextAttributes(color: .rgb(255, 165, 0))),
         ]
         let styledText = StyledText(spans: spans)
-        
+
         // Convert to ANSI tokens
         let tokens = converter.styledTextToTokens(styledText)
         let tokenizer = ANSITokenizer()
         let ansiString = tokenizer.encode(tokens)
-        
+
         print("Complex colors ANSI: \(ansiString)")
-        
+
         // Round-trip to verify preservation
         let parsedTokens = tokenizer.tokenize(ansiString)
         let roundTrip = converter.tokensToStyledText(parsedTokens)
-        
+
         print("Round-trip verification:")
         for (index, span) in roundTrip.spans.enumerated() {
             print("  Span \(index): '\(span.text)' - Color: \(span.attributes.color ?? .white)")
         }
     }
-    
+
     /// Demonstrates handling of all text attributes
     public static func allAttributes() {
         let converter = ANSISpanConverter()
-        
+
         // Create a span with all possible attributes
         let allAttributes = TextAttributes(
             color: .cyan,
@@ -132,24 +131,24 @@ public struct StyledTextExample {
             underline: true,
             inverse: true,
             strikethrough: true,
-            dim: true
+            dim: true,
         )
-        
+
         let span = TextSpan(text: "All attributes", attributes: allAttributes)
         let styledText = StyledText(spans: [span])
-        
+
         // Convert to ANSI and back
         let tokens = converter.styledTextToTokens(styledText)
         let tokenizer = ANSITokenizer()
         let ansiString = tokenizer.encode(tokens)
-        
+
         print("All attributes ANSI: \(ansiString)")
-        
+
         // Verify round-trip
         let parsedTokens = tokenizer.tokenize(ansiString)
         let roundTrip = converter.tokensToStyledText(parsedTokens)
         let resultAttrs = roundTrip.spans[0].attributes
-        
+
         print("Attribute preservation:")
         print("  Color: \(resultAttrs.color == allAttributes.color)")
         print("  Background: \(resultAttrs.backgroundColor == allAttributes.backgroundColor)")
@@ -160,21 +159,21 @@ public struct StyledTextExample {
         print("  Strikethrough: \(resultAttrs.strikethrough == allAttributes.strikethrough)")
         print("  Dim: \(resultAttrs.dim == allAttributes.dim)")
     }
-    
+
     /// Run all examples
     public static func runAllExamples() {
         print("=== Basic Conversion ===")
         basicConversion()
-        
+
         print("\n=== Merging Spans ===")
         mergingSpans()
-        
+
         print("\n=== Splitting Text ===")
         splittingText()
-        
+
         print("\n=== Complex Colors ===")
         complexColors()
-        
+
         print("\n=== All Attributes ===")
         allAttributes()
     }

--- a/Sources/RuneANSI/StyledTextSpan.swift
+++ b/Sources/RuneANSI/StyledTextSpan.swift
@@ -26,11 +26,11 @@ public enum ANSIColor: Equatable, Hashable {
     case brightMagenta
     case brightCyan
     case brightWhite
-    
+
     /// 256-color palette (0-255)
     /// - Parameter index: Color index in the 256-color palette
     case color256(Int)
-    
+
     /// RGB color with full 24-bit color support
     /// - Parameters:
     ///   - red: Red component (0-255)
@@ -46,28 +46,28 @@ public enum ANSIColor: Equatable, Hashable {
 public struct TextAttributes: Equatable, Hashable {
     /// Foreground text color
     public var color: ANSIColor?
-    
+
     /// Background color
     public var backgroundColor: ANSIColor?
-    
+
     /// Bold/bright text (SGR 1)
     public var bold: Bool
-    
+
     /// Italic text (SGR 3)
     public var italic: Bool
-    
+
     /// Underlined text (SGR 4)
     public var underline: Bool
-    
+
     /// Inverse/reverse video (SGR 7)
     public var inverse: Bool
-    
+
     /// Strikethrough text (SGR 9)
     public var strikethrough: Bool
-    
+
     /// Dim/faint text (SGR 2)
     public var dim: Bool
-    
+
     /// Initialize text attributes with optional styling
     ///
     /// - Parameters:
@@ -87,7 +87,7 @@ public struct TextAttributes: Equatable, Hashable {
         underline: Bool = false,
         inverse: Bool = false,
         strikethrough: Bool = false,
-        dim: Bool = false
+        dim: Bool = false,
     ) {
         self.color = color
         self.backgroundColor = backgroundColor
@@ -98,17 +98,17 @@ public struct TextAttributes: Equatable, Hashable {
         self.strikethrough = strikethrough
         self.dim = dim
     }
-    
+
     /// Check if attributes represent default (no styling)
     public var isDefault: Bool {
-        return color == nil &&
-               backgroundColor == nil &&
-               !bold &&
-               !italic &&
-               !underline &&
-               !inverse &&
-               !strikethrough &&
-               !dim
+        color == nil &&
+            backgroundColor == nil &&
+            !bold &&
+            !italic &&
+            !underline &&
+            !inverse &&
+            !strikethrough &&
+            !dim
     }
 }
 
@@ -120,10 +120,10 @@ public struct TextAttributes: Equatable, Hashable {
 public struct TextSpan: Equatable, Hashable {
     /// The text content of this span
     public let text: String
-    
+
     /// The styling attributes applied to this span
     public let attributes: TextAttributes
-    
+
     /// Initialize a text span
     ///
     /// - Parameters:
@@ -133,28 +133,28 @@ public struct TextSpan: Equatable, Hashable {
         self.text = text
         self.attributes = attributes
     }
-    
+
     /// Create a plain text span with no styling
     ///
     /// - Parameter text: The text content
     /// - Returns: A text span with default attributes
     public static func plain(_ text: String) -> TextSpan {
-        return TextSpan(text: text, attributes: TextAttributes())
+        TextSpan(text: text, attributes: TextAttributes())
     }
-    
+
     /// Check if this span has any styling applied
     public var isPlain: Bool {
-        return attributes.isDefault
+        attributes.isDefault
     }
-    
+
     /// The length of the text content
     public var length: Int {
-        return text.count
+        text.count
     }
-    
+
     /// Check if this span is empty
     public var isEmpty: Bool {
-        return text.isEmpty
+        text.isEmpty
     }
 
     /// Split this span at the specified character index
@@ -185,40 +185,40 @@ public struct TextSpan: Equatable, Hashable {
 public struct StyledText: Equatable {
     /// The text spans that make up this styled text
     public let spans: [TextSpan]
-    
+
     /// Initialize styled text with an array of spans
     ///
     /// - Parameter spans: The text spans to include
     public init(spans: [TextSpan]) {
         self.spans = spans
     }
-    
+
     /// Create styled text from plain text with no formatting
     ///
     /// - Parameter text: The plain text content
     /// - Returns: StyledText with a single plain span
     public static func plain(_ text: String) -> StyledText {
-        return StyledText(spans: [TextSpan.plain(text)])
+        StyledText(spans: [TextSpan.plain(text)])
     }
-    
+
     /// Extract the plain text content without any formatting
     public var plainText: String {
-        return spans.map { $0.text }.joined()
+        spans.map(\.text).joined()
     }
-    
+
     /// Check if this styled text is empty
     public var isEmpty: Bool {
-        return spans.isEmpty || spans.allSatisfy { $0.isEmpty }
+        spans.isEmpty || spans.allSatisfy(\.isEmpty)
     }
-    
+
     /// The total length of all text content
     public var length: Int {
-        return spans.reduce(0) { $0 + $1.length }
+        spans.reduce(0) { $0 + $1.length }
     }
-    
+
     /// Check if this styled text contains only plain text (no formatting)
     public var isPlain: Bool {
-        return spans.allSatisfy { $0.isPlain }
+        spans.allSatisfy(\.isPlain)
     }
 
     /// Merge adjacent spans with identical attributes
@@ -234,14 +234,14 @@ public struct StyledText: Equatable {
         var mergedSpans: [TextSpan] = []
         var currentSpan = spans[0]
 
-        for i in 1..<spans.count {
+        for i in 1 ..< spans.count {
             let nextSpan = spans[i]
 
             // If attributes match, merge the text
             if currentSpan.attributes == nextSpan.attributes {
                 currentSpan = TextSpan(
                     text: currentSpan.text + nextSpan.text,
-                    attributes: currentSpan.attributes
+                    attributes: currentSpan.attributes,
                 )
             } else {
                 // Attributes don't match, save current span and start new one
@@ -304,7 +304,7 @@ public struct StyledText: Equatable {
 
         return (
             left: StyledText(spans: leftSpans),
-            right: StyledText(spans: rightSpans)
+            right: StyledText(spans: rightSpans),
         )
     }
 }
@@ -315,7 +315,6 @@ public struct StyledText: Equatable {
 /// ANSI token representation and the higher-level styled text span model.
 /// It maintains state during conversion to properly handle SGR sequences.
 public struct ANSISpanConverter {
-
     public init() {}
 
     /// Convert ANSI tokens to styled text
@@ -332,10 +331,10 @@ public struct ANSISpanConverter {
 
         for token in tokens {
             switch token {
-            case .text(let text):
+            case let .text(text):
                 pendingText += text
 
-            case .sgr(let parameters):
+            case let .sgr(parameters):
                 // If we have pending text, create a span with current attributes
                 if !pendingText.isEmpty {
                     spans.append(TextSpan(text: pendingText, attributes: currentAttributes))
@@ -466,7 +465,7 @@ public struct ANSISpanConverter {
                 // Not strikethrough
                 newAttributes.strikethrough = false
 
-            case 30...37:
+            case 30 ... 37:
                 // Basic foreground colors
                 newAttributes.color = basicColor(from: param - 30)
 
@@ -481,7 +480,7 @@ public struct ANSISpanConverter {
                 // Default foreground color
                 newAttributes.color = nil
 
-            case 40...47:
+            case 40 ... 47:
                 // Basic background colors
                 newAttributes.backgroundColor = basicColor(from: param - 40)
 
@@ -496,11 +495,11 @@ public struct ANSISpanConverter {
                 // Default background color
                 newAttributes.backgroundColor = nil
 
-            case 90...97:
+            case 90 ... 97:
                 // Bright foreground colors
                 newAttributes.color = brightColor(from: param - 90)
 
-            case 100...107:
+            case 100 ... 107:
                 // Bright background colors
                 newAttributes.backgroundColor = brightColor(from: param - 100)
 
@@ -601,9 +600,9 @@ public struct ANSISpanConverter {
             return [brightOffset + 6]
         case .brightWhite:
             return [brightOffset + 7]
-        case .color256(let index):
+        case let .color256(index):
             return [isBackground ? 48 : 38, 5, index]
-        case .rgb(let red, let green, let blue):
+        case let .rgb(red, green, blue):
             return [isBackground ? 48 : 38, 2, red, green, blue]
         }
     }
@@ -614,7 +613,10 @@ public struct ANSISpanConverter {
     ///   - parameters: Full SGR parameter array
     ///   - startIndex: Index of the 38 or 48 parameter
     /// - Returns: Parsed color and next index, or nil if invalid
-    private func parseExtendedColor(_ parameters: [Int], startingAt startIndex: Int) -> (color: ANSIColor, nextIndex: Int)? {
+    private func parseExtendedColor(
+        _ parameters: [Int],
+        startingAt startIndex: Int,
+    ) -> (color: ANSIColor, nextIndex: Int)? {
         guard startIndex + 1 < parameters.count else { return nil }
 
         let colorType = parameters[startIndex + 1]
@@ -624,7 +626,7 @@ public struct ANSISpanConverter {
             // 256-color palette
             guard startIndex + 2 < parameters.count else { return nil }
             let colorIndex = parameters[startIndex + 2]
-            guard colorIndex >= 0 && colorIndex <= 255 else { return nil }
+            guard colorIndex >= 0, colorIndex <= 255 else { return nil }
             return (.color256(colorIndex), startIndex + 3)
 
         case 2:
@@ -633,9 +635,9 @@ public struct ANSISpanConverter {
             let red = parameters[startIndex + 2]
             let green = parameters[startIndex + 3]
             let blue = parameters[startIndex + 4]
-            guard red >= 0 && red <= 255 &&
-                  green >= 0 && green <= 255 &&
-                  blue >= 0 && blue <= 255 else { return nil }
+            guard red >= 0, red <= 255,
+                  green >= 0, green <= 255,
+                  blue >= 0, blue <= 255 else { return nil }
             return (.rgb(red, green, blue), startIndex + 5)
 
         default:
@@ -649,15 +651,15 @@ public struct ANSISpanConverter {
     /// - Returns: Corresponding ANSIColor
     private func basicColor(from index: Int) -> ANSIColor {
         switch index {
-        case 0: return .black
-        case 1: return .red
-        case 2: return .green
-        case 3: return .yellow
-        case 4: return .blue
-        case 5: return .magenta
-        case 6: return .cyan
-        case 7: return .white
-        default: return .white
+        case 0: .black
+        case 1: .red
+        case 2: .green
+        case 3: .yellow
+        case 4: .blue
+        case 5: .magenta
+        case 6: .cyan
+        case 7: .white
+        default: .white
         }
     }
 
@@ -667,15 +669,15 @@ public struct ANSISpanConverter {
     /// - Returns: Corresponding bright ANSIColor
     private func brightColor(from index: Int) -> ANSIColor {
         switch index {
-        case 0: return .brightBlack
-        case 1: return .brightRed
-        case 2: return .brightGreen
-        case 3: return .brightYellow
-        case 4: return .brightBlue
-        case 5: return .brightMagenta
-        case 6: return .brightCyan
-        case 7: return .brightWhite
-        default: return .brightWhite
+        case 0: .brightBlack
+        case 1: .brightRed
+        case 2: .brightGreen
+        case 3: .brightYellow
+        case 4: .brightBlue
+        case 5: .brightMagenta
+        case 6: .brightCyan
+        case 7: .brightWhite
+        default: .brightWhite
         }
     }
 }

--- a/Sources/RuneCLI/main.swift
+++ b/Sources/RuneCLI/main.swift
@@ -39,9 +39,21 @@ struct RuneCLI {
         let tokens = tokenizer.tokenize("Hello World")
         print("ANSI Tokenizer: \(tokens.count) tokens from 'Hello World'")
 
-        // Test width calculation
-        let width = Width.displayWidth(of: "Hello")
-        print("Unicode Width: 'Hello' has display width \(width)")
+        // Test width calculation with wcwidth bridge
+        let testCases = [
+            ("Hello", "ASCII text"),
+            ("café", "Text with accents"),
+            ("A\u{0300}", "A + combining grave"),
+            ("\u{0007}", "Control character (BEL)"),
+            ("\t", "Tab character"),
+            ("世界", "CJK characters"),
+        ]
+
+        print("Unicode Width calculations (wcwidth bridge):")
+        for (text, description) in testCases {
+            let width = Width.displayWidth(of: text)
+            print("  '\(text)' (\(description)): width = \(width)")
+        }
 
         // Test layout calculation
         let children = [FlexLayout.Size(width: 5, height: 1)]
@@ -82,7 +94,9 @@ struct RuneCLI {
             var attrDesc = ""
             if attrs.bold { attrDesc += "bold " }
             if let color = attrs.color { attrDesc += "\(color) " }
-            print("     \(index): '\(span.text)' (\(attrDesc.isEmpty ? "plain" : attrDesc.trimmingCharacters(in: .whitespaces)))")
+            print(
+                "     \(index): '\(span.text)' (\(attrDesc.isEmpty ? "plain" : attrDesc.trimmingCharacters(in: .whitespaces)))",
+            )
         }
 
         // Example 2: Merging spans
@@ -91,7 +105,7 @@ struct RuneCLI {
         let spans = [
             TextSpan(text: "Hello ", attributes: redBold),
             TextSpan(text: "beautiful ", attributes: redBold),
-            TextSpan(text: "world", attributes: redBold)
+            TextSpan(text: "world", attributes: redBold),
         ]
         let multiSpanText = StyledText(spans: spans)
         let merged = multiSpanText.mergingAdjacentSpans()
@@ -105,7 +119,7 @@ struct RuneCLI {
         let mixedText = StyledText(spans: [
             TextSpan(text: "Hello ", attributes: TextAttributes(color: .red)),
             TextSpan(text: "beautiful ", attributes: TextAttributes(bold: true)),
-            TextSpan(text: "world!", attributes: TextAttributes(color: .blue))
+            TextSpan(text: "world!", attributes: TextAttributes(color: .blue)),
         ])
 
         let (left, right) = mixedText.split(at: 10)

--- a/Sources/RuneUnicode/Width.swift
+++ b/Sources/RuneUnicode/Width.swift
@@ -6,41 +6,144 @@
 /// - CJK characters that are 2 columns wide
 /// - Zero-width joiners and combining characters
 /// - Control characters that have no width
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
 public enum Width {
     /// Calculate the display width of a string in terminal columns
     /// - Parameter string: The string to measure
     /// - Returns: Number of terminal columns the string will occupy
     public static func displayWidth(of string: String) -> Int {
-        // TODO: Implement proper width calculation
-        // For now, return basic ASCII-only implementation
-        string.count
+        var totalWidth = 0
+
+        for scalar in string.unicodeScalars {
+            totalWidth += displayWidth(of: scalar)
+        }
+
+        return totalWidth
     }
 
     /// Calculate the display width of a single Unicode scalar
     /// - Parameter scalar: The Unicode scalar to measure
     /// - Returns: Number of terminal columns (0, 1, or 2)
     public static func displayWidth(of scalar: Unicode.Scalar) -> Int {
-        // TODO: Implement proper scalar width calculation
-        // For now, return 1 for all printable characters
-        if scalar.isASCII, scalar.value >= 32, scalar.value < 127 {
-            return 1
+        let codePoint = scalar.value
+
+        // Handle special cases first before calling wcwidth
+
+        // Control characters (C0 and C1 control sets)
+        if (codePoint < 0x20) || (codePoint >= 0x7F && codePoint < 0xA0) {
+            // Special case: TAB should have width 1 for terminal display
+            if codePoint == 0x09 { // TAB
+                return 1
+            }
+            return 0 // Other control characters have zero width
         }
-        return 1 // Placeholder
+
+        // Use wcwidth for baseline width calculation
+        let result = wcwidth(wchar_t(codePoint))
+
+        // wcwidth returns:
+        // -1 for non-printable characters
+        //  0 for zero-width characters
+        //  1 for normal width characters
+        //  2 for wide characters (CJK, etc.)
+        switch result {
+        case -1:
+            // wcwidth returned -1, but we need to handle some cases manually
+            return handleUnrecognizedCharacter(codePoint)
+        case 0:
+            return 0 // Zero-width characters (combining marks, etc.)
+        case 1:
+            return 1 // Normal width
+        case 2:
+            return 2 // Wide characters
+        default:
+            // Fallback for unexpected values
+            return max(0, Int(result))
+        }
     }
 
     /// Check if a Unicode scalar is a zero-width character
     /// - Parameter scalar: The Unicode scalar to check
     /// - Returns: True if the character has zero display width
-    public static func isZeroWidth(_: Unicode.Scalar) -> Bool {
-        // TODO: Implement zero-width detection
-        false // Placeholder
+    public static func isZeroWidth(_ scalar: Unicode.Scalar) -> Bool {
+        displayWidth(of: scalar) == 0
     }
 
     /// Check if a Unicode scalar is wide (2 columns)
     /// - Parameter scalar: The Unicode scalar to check
     /// - Returns: True if the character occupies 2 terminal columns
-    public static func isWide(_: Unicode.Scalar) -> Bool {
-        // TODO: Implement wide character detection for CJK, etc.
-        false // Placeholder
+    public static func isWide(_ scalar: Unicode.Scalar) -> Bool {
+        displayWidth(of: scalar) == 2
+    }
+
+    /// Handle characters that wcwidth doesn't recognize (returns -1)
+    /// - Parameter codePoint: The Unicode code point
+    /// - Returns: The display width (0, 1, or 2)
+    private static func handleUnrecognizedCharacter(_ codePoint: UInt32) -> Int {
+        // Combining Diacritical Marks (U+0300-U+036F)
+        if codePoint >= 0x0300, codePoint <= 0x036F {
+            return 0
+        }
+
+        // Combining Diacritical Marks Extended (U+1AB0-U+1AFF)
+        if codePoint >= 0x1AB0, codePoint <= 0x1AFF {
+            return 0
+        }
+
+        // Combining Diacritical Marks Supplement (U+1DC0-U+1DFF)
+        if codePoint >= 0x1DC0, codePoint <= 0x1DFF {
+            return 0
+        }
+
+        // Combining Half Marks (U+FE20-U+FE2F)
+        if codePoint >= 0xFE20, codePoint <= 0xFE2F {
+            return 0
+        }
+
+        // CJK Symbols and Punctuation (U+3000-U+303F)
+        if codePoint >= 0x3000, codePoint <= 0x303F {
+            // U+3000 IDEOGRAPHIC SPACE is wide
+            if codePoint == 0x3000 {
+                return 2
+            }
+            return 1
+        }
+
+        // Latin-1 Supplement (U+00A0-U+00FF)
+        if codePoint >= 0x00A0, codePoint <= 0x00FF {
+            return 1
+        }
+
+        // General Punctuation (U+2000-U+206F)
+        if codePoint >= 0x2000, codePoint <= 0x206F {
+            // Zero-width spaces and format characters
+            if codePoint >= 0x200B, codePoint <= 0x200F {
+                return 0 // Zero-width spaces
+            }
+            if codePoint >= 0x202A, codePoint <= 0x202E {
+                return 0 // Bidirectional format characters
+            }
+            if codePoint >= 0x2060, codePoint <= 0x2064 {
+                return 0 // Invisible characters
+            }
+            return 1
+        }
+
+        // For other unrecognized characters, check if they're in the Basic Latin range
+        // that should be control characters
+        if codePoint == 0x7F {
+            return 0 // DEL character
+        }
+
+        // Default fallback for other unrecognized characters
+        return 1
     }
 }

--- a/StyledTextPlayground.swift
+++ b/StyledTextPlayground.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-// Since we can't import the package directly in a script, 
+// Since we can't import the package directly in a script,
 // you would need to copy the relevant source files or use this as a template
 // for a proper Swift Playground in Xcode.
 

--- a/Tests/RuneANSITests/ANSITokenizerTests.swift
+++ b/Tests/RuneANSITests/ANSITokenizerTests.swift
@@ -3,106 +3,105 @@ import Testing
 
 /// Tests for ANSI tokenizer functionality following TDD principles
 struct ANSITokenizerTests {
-    
     // MARK: - Basic Tokenization Tests
-    
+
     @Test("Empty string returns empty array")
-    func testTokenizeEmptyString() {
+    func tokenizeEmptyString() {
         // Arrange
         let tokenizer = ANSITokenizer()
         let input = ""
-        
+
         // Act
         let tokens = tokenizer.tokenize(input)
-        
+
         // Assert
         #expect(tokens.isEmpty, "Empty string should return empty token array")
     }
-    
+
     @Test("Plain text without ANSI codes")
-    func testTokenizePlainText() {
+    func tokenizePlainText() {
         // Arrange
         let tokenizer = ANSITokenizer()
         let input = "Hello World"
-        
+
         // Act
         let tokens = tokenizer.tokenize(input)
-        
+
         // Assert
         #expect(tokens == [.text("Hello World")], "Plain text should be tokenized as single text token")
     }
-    
+
     // MARK: - SGR (Styling) Tests - These will initially fail
-    
+
     @Test("Simple SGR color code")
-    func testTokenizeSimpleSGR() {
+    func tokenizeSimpleSGR() {
         // Arrange
         let tokenizer = ANSITokenizer()
         let input = "\u{001B}[31mRed Text\u{001B}[0m"
-        
+
         // Act
         let tokens = tokenizer.tokenize(input)
-        
+
         // Assert
         let expected: [ANSIToken] = [
             .sgr([31]),
             .text("Red Text"),
-            .sgr([0])
+            .sgr([0]),
         ]
         #expect(tokens == expected, "SGR codes should be properly tokenized")
     }
-    
+
     @Test("Multiple SGR parameters")
-    func testTokenizeMultipleSGRParameters() {
+    func tokenizeMultipleSGRParameters() {
         // Arrange
         let tokenizer = ANSITokenizer()
         let input = "\u{001B}[1;31mBold Red\u{001B}[0m"
-        
+
         // Act
         let tokens = tokenizer.tokenize(input)
-        
+
         // Assert
         let expected: [ANSIToken] = [
             .sgr([1, 31]),
             .text("Bold Red"),
-            .sgr([0])
+            .sgr([0]),
         ]
         #expect(tokens == expected, "Multiple SGR parameters should be parsed correctly")
     }
-    
+
     // MARK: - Cursor Movement Tests - These will initially fail
-    
+
     @Test("Cursor up movement")
-    func testTokenizeCursorUp() {
+    func tokenizeCursorUp() {
         // Arrange
         let tokenizer = ANSITokenizer()
         let input = "\u{001B}[3A"
-        
+
         // Act
         let tokens = tokenizer.tokenize(input)
-        
+
         // Assert
         #expect(tokens == [.cursor(3, "A")], "Cursor up should be tokenized correctly")
     }
-    
+
     // MARK: - Mixed Content Tests - These will initially fail
-    
+
     @Test("Mixed text and ANSI codes")
-    func testTokenizeMixedContent() {
+    func tokenizeMixedContent() {
         // Arrange
         let tokenizer = ANSITokenizer()
         let input = "Hello \u{001B}[31mRed\u{001B}[0m World"
-        
+
         // Act
         let tokens = tokenizer.tokenize(input)
-        
+
         // Assert
         let expected: [ANSIToken] = [
             .text("Hello "),
             .sgr([31]),
             .text("Red"),
             .sgr([0]),
-            .text(" World")
+            .text(" World"),
         ]
         #expect(tokens == expected, "Mixed content should be tokenized correctly")
     }
@@ -387,7 +386,7 @@ struct ANSITokenizerTests {
 
         // Verify specific patterns
         let hasGreenCheckmark = tokens.contains { token in
-            if case .sgr(let params) = token, params == [32] { return true }
+            if case let .sgr(params) = token, params == [32] { return true }
             return false
         }
         #expect(hasGreenCheckmark, "Should contain green color code for checkmark")
@@ -479,7 +478,7 @@ struct ANSITokenizerTests {
 
         // The invalid sequence should be handled somehow (either as control or text)
         let hasValidReset = tokens.contains { token in
-            if case .sgr(let params) = token, params == [0] { return true }
+            if case let .sgr(params) = token, params == [0] { return true }
             return false
         }
         #expect(hasValidReset, "Valid reset sequence should still be parsed")
@@ -497,7 +496,7 @@ struct ANSITokenizerTests {
         // Assert
         // Should handle empty parameters gracefully
         #expect(tokens.count == 1, "Empty parameters should produce one token")
-        if case .sgr(let params) = tokens[0] {
+        if case let .sgr(params) = tokens[0] {
             // Empty parameters should be treated as 0 or filtered out
             #expect(params.isEmpty || params == [0], "Empty parameters should be handled gracefully")
         } else {

--- a/Tests/RuneANSITests/StyledTextExampleTests.swift
+++ b/Tests/RuneANSITests/StyledTextExampleTests.swift
@@ -1,22 +1,21 @@
-import Testing
 import Foundation
+import Testing
 @testable import RuneANSI
 
 /// Tests that run the styled text examples to demonstrate functionality
 struct StyledTextExampleTests {
-    
     @Test("Run basic conversion example")
-    func testBasicConversionExample() {
+    func basicConversionExample() {
         let tokenizer = ANSITokenizer()
         let converter = ANSISpanConverter()
-        
+
         // Parse ANSI-formatted text
         let input = "\u{001B}[1;31mError:\u{001B}[0m \u{001B}[33mWarning message\u{001B}[0m"
         let tokens = tokenizer.tokenize(input)
-        
+
         // Convert to styled text spans
         let styledText = converter.tokensToStyledText(tokens)
-        
+
         print("=== Basic Conversion Example ===")
         print("Input (raw): \(input.debugDescription)")
         print("Spans:")
@@ -25,7 +24,9 @@ struct StyledTextExampleTests {
             var attrDesc = ""
             if attrs.bold { attrDesc += "bold " }
             if let color = attrs.color { attrDesc += "\(color) " }
-            print("  \(index): '\(span.text)' (\(attrDesc.isEmpty ? "plain" : attrDesc.trimmingCharacters(in: .whitespaces)))")
+            print(
+                "  \(index): '\(span.text)' (\(attrDesc.isEmpty ? "plain" : attrDesc.trimmingCharacters(in: .whitespaces)))",
+            )
         }
 
         // Convert back to ANSI
@@ -33,7 +34,7 @@ struct StyledTextExampleTests {
         let output = tokenizer.encode(outputTokens)
         print("Round-trip (raw): \(output.debugDescription)")
         print("Identical: \(input == output)")
-        
+
         // Verify the example works correctly
         #expect(styledText.spans.count == 3, "Should have 3 spans")
 
@@ -51,58 +52,58 @@ struct StyledTextExampleTests {
         #expect(styledText.spans[2].text == "Warning message", "Third span should be 'Warning message'")
         #expect(styledText.spans[2].attributes.color == .yellow, "Third span should be yellow")
     }
-    
+
     @Test("Run merging spans example")
-    func testMergingSpansExample() {
+    func mergingSpansExample() {
         // Create styled text with adjacent spans that have the same attributes
         let redBold = TextAttributes(color: .red, bold: true)
         let spans = [
             TextSpan(text: "Hello ", attributes: redBold),
             TextSpan(text: "beautiful ", attributes: redBold),
-            TextSpan(text: "world", attributes: redBold)
+            TextSpan(text: "world", attributes: redBold),
         ]
         let styledText = StyledText(spans: spans)
-        
+
         print("\n=== Merging Spans Example ===")
         print("Before merging: \(styledText.spans.count) spans")
         for span in styledText.spans {
             print("  '\(span.text)'")
         }
-        
+
         // Merge adjacent spans
         let merged = styledText.mergingAdjacentSpans()
-        
+
         print("After merging: \(merged.spans.count) spans")
         for span in merged.spans {
             print("  '\(span.text)'")
         }
-        
+
         // Verify the example works correctly
         #expect(styledText.spans.count == 3, "Should start with 3 spans")
         #expect(merged.spans.count == 1, "Should merge to 1 span")
         #expect(merged.spans[0].text == "Hello beautiful world", "Text should be concatenated")
     }
-    
+
     @Test("Run splitting text example")
-    func testSplittingTextExample() {
+    func splittingTextExample() {
         // Create styled text with multiple spans
         let styledText = StyledText(spans: [
             TextSpan(text: "Hello ", attributes: TextAttributes(color: .red)),
             TextSpan(text: "beautiful ", attributes: TextAttributes(bold: true)),
-            TextSpan(text: "world!", attributes: TextAttributes(color: .blue))
+            TextSpan(text: "world!", attributes: TextAttributes(color: .blue)),
         ])
-        
+
         print("\n=== Splitting Text Example ===")
         print("Original text: '\(styledText.plainText)'")
         print("Length: \(styledText.length)")
-        
+
         // Split at column 10
         let (left, right) = styledText.split(at: 10)
-        
+
         print("Split at column 10:")
         print("  Left: '\(left.plainText)' (\(left.spans.count) spans)")
         print("  Right: '\(right.plainText)' (\(right.spans.count) spans)")
-        
+
         // Demonstrate that attributes are preserved
         for (index, span) in left.spans.enumerated() {
             print("    Left span \(index): '\(span.text)' - \(span.attributes)")
@@ -110,54 +111,54 @@ struct StyledTextExampleTests {
         for (index, span) in right.spans.enumerated() {
             print("    Right span \(index): '\(span.text)' - \(span.attributes)")
         }
-        
+
         // Verify the example works correctly
         #expect(left.plainText == "Hello beau", "Left part should be 'Hello beau'")
         #expect(right.plainText == "tiful world!", "Right part should be 'tiful world!'")
         #expect(left.spans.count == 2, "Left should have 2 spans")
         #expect(right.spans.count == 2, "Right should have 2 spans")
     }
-    
+
     @Test("Run complex colors example")
-    func testComplexColorsExample() {
+    func complexColorsExample() {
         let converter = ANSISpanConverter()
-        
+
         // Create spans with different color formats
         let spans = [
             TextSpan(text: "Basic red ", attributes: TextAttributes(color: .red)),
             TextSpan(text: "256-color ", attributes: TextAttributes(color: .color256(196))),
-            TextSpan(text: "RGB orange", attributes: TextAttributes(color: .rgb(255, 165, 0)))
+            TextSpan(text: "RGB orange", attributes: TextAttributes(color: .rgb(255, 165, 0))),
         ]
         let styledText = StyledText(spans: spans)
-        
+
         // Convert to ANSI tokens
         let tokens = converter.styledTextToTokens(styledText)
         let tokenizer = ANSITokenizer()
         let ansiString = tokenizer.encode(tokens)
-        
+
         print("\n=== Complex Colors Example ===")
         print("Complex colors ANSI (raw): \(ansiString.debugDescription)")
-        
+
         // Round-trip to verify preservation
         let parsedTokens = tokenizer.tokenize(ansiString)
         let roundTrip = converter.tokensToStyledText(parsedTokens)
-        
+
         print("Round-trip verification:")
         for (index, span) in roundTrip.spans.enumerated() {
             print("  Span \(index): '\(span.text)' - Color: \(span.attributes.color ?? .white)")
         }
-        
+
         // Verify the example works correctly
         #expect(roundTrip.spans.count == 3, "Should have 3 spans after round-trip")
         #expect(roundTrip.spans[0].attributes.color == .red, "First span should be red")
         #expect(roundTrip.spans[1].attributes.color == .color256(196), "Second span should be 256-color")
         #expect(roundTrip.spans[2].attributes.color == .rgb(255, 165, 0), "Third span should be RGB")
     }
-    
+
     @Test("Run all attributes example")
-    func testAllAttributesExample() {
+    func allAttributesExample() {
         let converter = ANSISpanConverter()
-        
+
         // Create a span with all possible attributes
         let allAttributes = TextAttributes(
             color: .cyan,
@@ -167,25 +168,25 @@ struct StyledTextExampleTests {
             underline: true,
             inverse: true,
             strikethrough: true,
-            dim: true
+            dim: true,
         )
-        
+
         let span = TextSpan(text: "All attributes", attributes: allAttributes)
         let styledText = StyledText(spans: [span])
-        
+
         // Convert to ANSI and back
         let tokens = converter.styledTextToTokens(styledText)
         let tokenizer = ANSITokenizer()
         let ansiString = tokenizer.encode(tokens)
-        
+
         print("\n=== All Attributes Example ===")
         print("All attributes ANSI (raw): \(ansiString.debugDescription)")
-        
+
         // Verify round-trip
         let parsedTokens = tokenizer.tokenize(ansiString)
         let roundTrip = converter.tokensToStyledText(parsedTokens)
         let resultAttrs = roundTrip.spans[0].attributes
-        
+
         print("Attribute preservation:")
         print("  Color: \(resultAttrs.color == allAttributes.color)")
         print("  Background: \(resultAttrs.backgroundColor == allAttributes.backgroundColor)")
@@ -195,7 +196,7 @@ struct StyledTextExampleTests {
         print("  Inverse: \(resultAttrs.inverse == allAttributes.inverse)")
         print("  Strikethrough: \(resultAttrs.strikethrough == allAttributes.strikethrough)")
         print("  Dim: \(resultAttrs.dim == allAttributes.dim)")
-        
+
         // Verify all attributes are preserved
         #expect(resultAttrs.color == allAttributes.color, "Color should be preserved")
         #expect(resultAttrs.backgroundColor == allAttributes.backgroundColor, "Background should be preserved")

--- a/Tests/RuneANSITests/StyledTextSpanTests.swift
+++ b/Tests/RuneANSITests/StyledTextSpanTests.swift
@@ -1,17 +1,16 @@
-import Testing
 import Foundation
+import Testing
 @testable import RuneANSI
 
 /// Tests for styled text spans functionality following TDD principles
 struct StyledTextSpanTests {
-    
     // MARK: - Text Attributes Tests
-    
+
     @Test("Default text attributes should have no styling")
-    func testDefaultTextAttributes() {
+    func defaultTextAttributes() {
         // Arrange & Act
         let attributes = TextAttributes()
-        
+
         // Assert
         #expect(attributes.color == nil, "Default color should be nil")
         #expect(attributes.backgroundColor == nil, "Default background color should be nil")
@@ -22,161 +21,161 @@ struct StyledTextSpanTests {
         #expect(attributes.strikethrough == false, "Default strikethrough should be false")
         #expect(attributes.dim == false, "Default dim should be false")
     }
-    
+
     @Test("Text attributes with bold styling")
-    func testTextAttributesBold() {
+    func textAttributesBold() {
         // Arrange & Act
         let attributes = TextAttributes(bold: true)
-        
+
         // Assert
         #expect(attributes.bold == true, "Bold should be true")
         #expect(attributes.italic == false, "Other attributes should remain default")
     }
-    
+
     @Test("Text attributes with color")
-    func testTextAttributesWithColor() {
+    func textAttributesWithColor() {
         // Arrange & Act
         let attributes = TextAttributes(color: .red)
-        
+
         // Assert
         #expect(attributes.color == .red, "Color should be red")
         #expect(attributes.bold == false, "Other attributes should remain default")
     }
-    
+
     @Test("Text attributes equality")
-    func testTextAttributesEquality() {
+    func textAttributesEquality() {
         // Arrange
         let attrs1 = TextAttributes(color: .red, bold: true)
         let attrs2 = TextAttributes(color: .red, bold: true)
         let attrs3 = TextAttributes(color: .blue, bold: true)
-        
+
         // Act & Assert
         #expect(attrs1 == attrs2, "Identical attributes should be equal")
         #expect(attrs1 != attrs3, "Different attributes should not be equal")
     }
-    
+
     // MARK: - Color Tests
-    
+
     @Test("Basic ANSI colors")
-    func testBasicANSIColors() {
+    func basicANSIColors() {
         // Arrange & Act
         let red = ANSIColor.red
         let green = ANSIColor.green
         let blue = ANSIColor.blue
-        
+
         // Assert
         #expect(red != green, "Different colors should not be equal")
         #expect(red == ANSIColor.red, "Same colors should be equal")
     }
-    
+
     @Test("256-color palette")
     func testColor256() {
         // Arrange & Act
         let color196 = ANSIColor.color256(196) // Bright red
-        let color21 = ANSIColor.color256(21)   // Bright blue
-        
+        let color21 = ANSIColor.color256(21) // Bright blue
+
         // Assert
         #expect(color196 != color21, "Different 256 colors should not be equal")
         #expect(color196 == ANSIColor.color256(196), "Same 256 colors should be equal")
     }
-    
+
     @Test("RGB colors")
-    func testRGBColors() {
+    func rGBColors() {
         // Arrange & Act
         let red = ANSIColor.rgb(255, 0, 0)
         let green = ANSIColor.rgb(0, 255, 0)
         let sameRed = ANSIColor.rgb(255, 0, 0)
-        
+
         // Assert
         #expect(red != green, "Different RGB colors should not be equal")
         #expect(red == sameRed, "Same RGB colors should be equal")
     }
-    
+
     // MARK: - Text Span Tests
-    
+
     @Test("Text span with plain text")
-    func testTextSpanPlain() {
+    func textSpanPlain() {
         // Arrange & Act
         let span = TextSpan(text: "Hello World", attributes: TextAttributes())
-        
+
         // Assert
         #expect(span.text == "Hello World", "Text should be preserved")
         #expect(span.attributes == TextAttributes(), "Attributes should be default")
     }
-    
+
     @Test("Text span with styled attributes")
-    func testTextSpanStyled() {
+    func textSpanStyled() {
         // Arrange
         let attributes = TextAttributes(color: .red, bold: true)
-        
+
         // Act
         let span = TextSpan(text: "Bold Red", attributes: attributes)
-        
+
         // Assert
         #expect(span.text == "Bold Red", "Text should be preserved")
         #expect(span.attributes.color == .red, "Color should be red")
         #expect(span.attributes.bold == true, "Bold should be true")
     }
-    
+
     @Test("Text span equality")
-    func testTextSpanEquality() {
+    func textSpanEquality() {
         // Arrange
         let attrs = TextAttributes(color: .blue)
         let span1 = TextSpan(text: "Hello", attributes: attrs)
         let span2 = TextSpan(text: "Hello", attributes: attrs)
         let span3 = TextSpan(text: "World", attributes: attrs)
-        
+
         // Act & Assert
         #expect(span1 == span2, "Identical spans should be equal")
         #expect(span1 != span3, "Different spans should not be equal")
     }
-    
+
     // MARK: - Styled Text Tests
-    
+
     @Test("Styled text with single span")
-    func testStyledTextSingleSpan() {
+    func styledTextSingleSpan() {
         // Arrange
         let span = TextSpan(text: "Hello", attributes: TextAttributes())
-        
+
         // Act
         let styledText = StyledText(spans: [span])
-        
+
         // Assert
         #expect(styledText.spans.count == 1, "Should have one span")
         #expect(styledText.spans[0] == span, "Span should be preserved")
     }
-    
+
     @Test("Styled text with multiple spans")
-    func testStyledTextMultipleSpans() {
+    func styledTextMultipleSpans() {
         // Arrange
         let span1 = TextSpan(text: "Hello ", attributes: TextAttributes())
         let span2 = TextSpan(text: "World", attributes: TextAttributes(bold: true))
-        
+
         // Act
         let styledText = StyledText(spans: [span1, span2])
-        
+
         // Assert
         #expect(styledText.spans.count == 2, "Should have two spans")
         #expect(styledText.spans[0] == span1, "First span should be preserved")
         #expect(styledText.spans[1] == span2, "Second span should be preserved")
     }
-    
+
     @Test("Styled text plain text extraction")
-    func testStyledTextPlainText() {
+    func styledTextPlainText() {
         // Arrange
         let span1 = TextSpan(text: "Hello ", attributes: TextAttributes())
         let span2 = TextSpan(text: "World", attributes: TextAttributes(bold: true))
         let styledText = StyledText(spans: [span1, span2])
-        
+
         // Act
         let plainText = styledText.plainText
-        
+
         // Assert
         #expect(plainText == "Hello World", "Plain text should concatenate all span text")
     }
-    
+
     @Test("Empty styled text")
-    func testEmptyStyledText() {
+    func emptyStyledText() {
         // Arrange & Act
         let styledText = StyledText(spans: [])
 
@@ -188,7 +187,7 @@ struct StyledTextSpanTests {
     // MARK: - ANSI Tokens to Spans Conversion Tests
 
     @Test("Convert plain text tokens to spans")
-    func testTokensToSpansPlainText() {
+    func tokensToSpansPlainText() {
         // Arrange
         let tokens: [ANSIToken] = [.text("Hello World")]
         let converter = ANSISpanConverter()
@@ -203,12 +202,12 @@ struct StyledTextSpanTests {
     }
 
     @Test("Convert simple SGR tokens to spans")
-    func testTokensToSpansSimpleSGR() {
+    func tokensToSpansSimpleSGR() {
         // Arrange
         let tokens: [ANSIToken] = [
-            .sgr([31]),        // Red color
+            .sgr([31]), // Red color
             .text("Red Text"),
-            .sgr([0])          // Reset
+            .sgr([0]), // Reset
         ]
         let converter = ANSISpanConverter()
 
@@ -222,14 +221,14 @@ struct StyledTextSpanTests {
     }
 
     @Test("Convert multiple SGR tokens to spans")
-    func testTokensToSpansMultipleSGR() {
+    func tokensToSpansMultipleSGR() {
         // Arrange
         let tokens: [ANSIToken] = [
-            .sgr([1]),         // Bold
+            .sgr([1]), // Bold
             .text("Bold "),
-            .sgr([31]),        // Add red color
+            .sgr([31]), // Add red color
             .text("Bold Red"),
-            .sgr([0])          // Reset
+            .sgr([0]), // Reset
         ]
         let converter = ANSISpanConverter()
 
@@ -248,15 +247,15 @@ struct StyledTextSpanTests {
     }
 
     @Test("Convert mixed tokens with non-SGR sequences")
-    func testTokensToSpansMixed() {
+    func tokensToSpansMixed() {
         // Arrange
         let tokens: [ANSIToken] = [
             .text("Before "),
-            .cursor(3, "A"),   // Non-SGR token (should be ignored for styling)
+            .cursor(3, "A"), // Non-SGR token (should be ignored for styling)
             .sgr([31]),
             .text("Red"),
             .sgr([0]),
-            .text(" After")
+            .text(" After"),
         ]
         let converter = ANSISpanConverter()
 
@@ -272,14 +271,14 @@ struct StyledTextSpanTests {
     }
 
     @Test("Convert 256-color tokens to spans")
-    func testTokensToSpans256Color() {
+    func tokensToSpans256Color() {
         // Arrange
         let tokens: [ANSIToken] = [
             .sgr([38, 5, 196]), // 256-color red foreground
             .text("256 Red"),
-            .sgr([48, 5, 21]),  // 256-color blue background
+            .sgr([48, 5, 21]), // 256-color blue background
             .text(" with Blue BG"),
-            .sgr([0])
+            .sgr([0]),
         ]
         let converter = ANSISpanConverter()
 
@@ -290,16 +289,19 @@ struct StyledTextSpanTests {
         #expect(styledText.spans.count == 2, "Should have two spans")
         #expect(styledText.spans[0].attributes.color == .color256(196), "First span should have 256-color red")
         #expect(styledText.spans[1].attributes.color == .color256(196), "Second span should inherit color")
-        #expect(styledText.spans[1].attributes.backgroundColor == .color256(21), "Second span should have blue background")
+        #expect(
+            styledText.spans[1].attributes.backgroundColor == .color256(21),
+            "Second span should have blue background",
+        )
     }
 
     @Test("Convert RGB color tokens to spans")
-    func testTokensToSpansRGBColor() {
+    func tokensToSpansRGBColor() {
         // Arrange
         let tokens: [ANSIToken] = [
             .sgr([38, 2, 255, 128, 0]), // RGB orange foreground
             .text("RGB Orange"),
-            .sgr([0])
+            .sgr([0]),
         ]
         let converter = ANSISpanConverter()
 
@@ -312,7 +314,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Convert empty token array")
-    func testTokensToSpansEmpty() {
+    func tokensToSpansEmpty() {
         // Arrange
         let tokens: [ANSIToken] = []
         let converter = ANSISpanConverter()
@@ -326,12 +328,12 @@ struct StyledTextSpanTests {
     }
 
     @Test("Convert tokens with only SGR (no text)")
-    func testTokensToSpansOnlySGR() {
+    func tokensToSpansOnlySGR() {
         // Arrange
         let tokens: [ANSIToken] = [
             .sgr([1]),
             .sgr([31]),
-            .sgr([0])
+            .sgr([0]),
         ]
         let converter = ANSISpanConverter()
 
@@ -345,7 +347,7 @@ struct StyledTextSpanTests {
     // MARK: - Spans to ANSI Tokens Conversion Tests
 
     @Test("Convert plain text spans to tokens")
-    func testSpansToTokensPlainText() {
+    func spansToTokensPlainText() {
         // Arrange
         let span = TextSpan(text: "Hello World", attributes: TextAttributes())
         let styledText = StyledText(spans: [span])
@@ -360,7 +362,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Convert styled spans to tokens")
-    func testSpansToTokensStyled() {
+    func spansToTokensStyled() {
         // Arrange
         let attributes = TextAttributes(color: .red, bold: true)
         let span = TextSpan(text: "Bold Red", attributes: attributes)
@@ -374,7 +376,7 @@ struct StyledTextSpanTests {
         #expect(tokens.count == 3, "Should have SGR, text, and reset tokens")
 
         // Check SGR token contains both bold and red
-        if case .sgr(let params) = tokens[0] {
+        if case let .sgr(params) = tokens[0] {
             #expect(params.contains(1), "Should contain bold parameter")
             #expect(params.contains(31), "Should contain red parameter")
         } else {
@@ -386,7 +388,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Convert multiple spans to tokens")
-    func testSpansToTokensMultiple() {
+    func spansToTokensMultiple() {
         // Arrange
         let span1 = TextSpan(text: "Plain ", attributes: TextAttributes())
         let span2 = TextSpan(text: "Bold", attributes: TextAttributes(bold: true))
@@ -408,7 +410,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Convert 256-color spans to tokens")
-    func testSpansToTokens256Color() {
+    func spansToTokens256Color() {
         // Arrange
         let attributes = TextAttributes(color: .color256(196))
         let span = TextSpan(text: "256 Red", attributes: attributes)
@@ -426,7 +428,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Convert RGB color spans to tokens")
-    func testSpansToTokensRGBColor() {
+    func spansToTokensRGBColor() {
         // Arrange
         let attributes = TextAttributes(color: .rgb(255, 128, 0))
         let span = TextSpan(text: "RGB Orange", attributes: attributes)
@@ -444,7 +446,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Convert empty styled text to tokens")
-    func testSpansToTokensEmpty() {
+    func spansToTokensEmpty() {
         // Arrange
         let styledText = StyledText(spans: [])
         let converter = ANSISpanConverter()
@@ -459,7 +461,7 @@ struct StyledTextSpanTests {
     // MARK: - Round-trip Conversion Tests
 
     @Test("Round-trip conversion preserves plain text")
-    func testRoundTripPlainText() {
+    func roundTripPlainText() {
         // Arrange
         let originalTokens: [ANSIToken] = [.text("Hello World")]
         let converter = ANSISpanConverter()
@@ -473,12 +475,12 @@ struct StyledTextSpanTests {
     }
 
     @Test("Round-trip conversion preserves simple styling")
-    func testRoundTripSimpleStyling() {
+    func roundTripSimpleStyling() {
         // Arrange
         let originalTokens: [ANSIToken] = [
             .sgr([31]),
             .text("Red Text"),
-            .sgr([0])
+            .sgr([0]),
         ]
         let converter = ANSISpanConverter()
 
@@ -491,14 +493,14 @@ struct StyledTextSpanTests {
     }
 
     @Test("Round-trip conversion preserves complex styling")
-    func testRoundTripComplexStyling() {
+    func roundTripComplexStyling() {
         // Arrange
         let originalTokens: [ANSIToken] = [
-            .sgr([1, 31]),        // Bold red
+            .sgr([1, 31]), // Bold red
             .text("Bold Red "),
-            .sgr([4]),            // Add underline
+            .sgr([4]), // Add underline
             .text("Bold Red Underline"),
-            .sgr([0])             // Reset
+            .sgr([0]), // Reset
         ]
         let converter = ANSISpanConverter()
 
@@ -519,12 +521,12 @@ struct StyledTextSpanTests {
     }
 
     @Test("Round-trip conversion preserves 256-color")
-    func testRoundTrip256Color() {
+    func roundTrip256Color() {
         // Arrange
         let originalTokens: [ANSIToken] = [
             .sgr([38, 5, 196]),
             .text("256 Color"),
-            .sgr([0])
+            .sgr([0]),
         ]
         let converter = ANSISpanConverter()
 
@@ -537,12 +539,12 @@ struct StyledTextSpanTests {
     }
 
     @Test("Round-trip conversion preserves RGB color")
-    func testRoundTripRGBColor() {
+    func roundTripRGBColor() {
         // Arrange
         let originalTokens: [ANSIToken] = [
             .sgr([38, 2, 255, 128, 0]),
             .text("RGB Color"),
-            .sgr([0])
+            .sgr([0]),
         ]
         let converter = ANSISpanConverter()
 
@@ -557,7 +559,7 @@ struct StyledTextSpanTests {
     // MARK: - Span Utilities Tests
 
     @Test("Merge adjacent compatible spans")
-    func testMergeAdjacentSpans() {
+    func mergeAdjacentSpans() {
         // Arrange
         let attributes = TextAttributes(color: .red, bold: true)
         let span1 = TextSpan(text: "Hello ", attributes: attributes)
@@ -574,7 +576,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Don't merge spans with different attributes")
-    func testDontMergeDifferentAttributes() {
+    func dontMergeDifferentAttributes() {
         // Arrange
         let attrs1 = TextAttributes(color: .red)
         let attrs2 = TextAttributes(color: .blue)
@@ -592,7 +594,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Merge multiple adjacent compatible spans")
-    func testMergeMultipleAdjacentSpans() {
+    func mergeMultipleAdjacentSpans() {
         // Arrange
         let attributes = TextAttributes(bold: true)
         let span1 = TextSpan(text: "Hello ", attributes: attributes)
@@ -610,7 +612,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Split span at character boundary")
-    func testSplitSpanAtBoundary() {
+    func splitSpanAtBoundary() {
         // Arrange
         let attributes = TextAttributes(color: .red, bold: true)
         let span = TextSpan(text: "Hello World", attributes: attributes)
@@ -626,7 +628,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Split span at beginning")
-    func testSplitSpanAtBeginning() {
+    func splitSpanAtBeginning() {
         // Arrange
         let attributes = TextAttributes(italic: true)
         let span = TextSpan(text: "Hello", attributes: attributes)
@@ -642,7 +644,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Split span at end")
-    func testSplitSpanAtEnd() {
+    func splitSpanAtEnd() {
         // Arrange
         let attributes = TextAttributes(underline: true)
         let span = TextSpan(text: "Hello", attributes: attributes)
@@ -658,7 +660,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Split styled text at column boundary")
-    func testSplitStyledTextAtColumn() {
+    func splitStyledTextAtColumn() {
         // Arrange
         let span1 = TextSpan(text: "Hello ", attributes: TextAttributes(color: .red))
         let span2 = TextSpan(text: "World", attributes: TextAttributes(bold: true))
@@ -680,14 +682,14 @@ struct StyledTextSpanTests {
     // MARK: - Edge Case Tests
 
     @Test("Handle malformed SGR parameters gracefully")
-    func testMalformedSGRParameters() {
+    func malformedSGRParameters() {
         // Arrange
         let tokens: [ANSIToken] = [
             .sgr([38, 5]), // Incomplete 256-color sequence
             .text("Text"),
             .sgr([38, 2, 255]), // Incomplete RGB sequence
             .text("More"),
-            .sgr([0])
+            .sgr([0]),
         ]
         let converter = ANSISpanConverter()
 
@@ -700,7 +702,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Handle empty spans in merge")
-    func testMergeWithEmptySpans() {
+    func mergeWithEmptySpans() {
         // Arrange
         let attributes = TextAttributes(bold: true)
         let span1 = TextSpan(text: "Hello", attributes: attributes)
@@ -717,7 +719,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Split at invalid indices")
-    func testSplitAtInvalidIndices() {
+    func splitAtInvalidIndices() {
         // Arrange
         let span = TextSpan(text: "Hello", attributes: TextAttributes(bold: true))
 
@@ -733,7 +735,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Complex attribute combinations")
-    func testComplexAttributeCombinations() {
+    func complexAttributeCombinations() {
         // Arrange
         let attributes = TextAttributes(
             color: .rgb(255, 128, 64),
@@ -743,7 +745,7 @@ struct StyledTextSpanTests {
             underline: true,
             inverse: true,
             strikethrough: true,
-            dim: true
+            dim: true,
         )
         let span = TextSpan(text: "Complex", attributes: attributes)
         let styledText = StyledText(spans: [span])
@@ -767,7 +769,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Unicode text handling")
-    func testUnicodeTextHandling() {
+    func unicodeTextHandling() {
         // Arrange
         let unicodeText = "Hello 🌍 世界 🎉"
         let attributes = TextAttributes(color: .blue)
@@ -785,7 +787,7 @@ struct StyledTextSpanTests {
     }
 
     @Test("Large text performance")
-    func testLargeTextPerformance() {
+    func largeTextPerformance() {
         // Arrange
         let largeText = String(repeating: "A", count: 10000)
         let attributes = TextAttributes(color: .red)

--- a/Tests/RuneUnicodeTests/WidthTests.swift
+++ b/Tests/RuneUnicodeTests/WidthTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import RuneUnicode
 
@@ -133,15 +134,171 @@ struct WidthTests {
         #expect(width == 1, "ASCII character should have width 1")
     }
 
-    @Test("Space scalar width")
-    func spaceScalarWidth() {
-        // Arrange
-        let scalar = Unicode.Scalar(32)! // ' '
+    // MARK: - wcwidth/wcswidth Bridge Tests (RUNE-16)
 
-        // Act
-        let width = Width.displayWidth(of: scalar)
+    @Test("Control characters have zero width")
+    func controlCharacterWidth() {
+        // Arrange - Test various control characters
+        let controlChars: [Unicode.Scalar] = [
+            Unicode.Scalar(0)!, // NULL
+            Unicode.Scalar(7)!, // BEL
+            Unicode.Scalar(8)!, // BS
+            Unicode.Scalar(9)!, // TAB - special case, should be 1
+            Unicode.Scalar(10)!, // LF
+            Unicode.Scalar(13)!, // CR
+            Unicode.Scalar(27)!, // ESC
+            Unicode.Scalar(127)!, // DEL
+        ]
 
-        // Assert
-        #expect(width == 1, "Space character should have width 1")
+        for scalar in controlChars {
+            // Act
+            let width = Width.displayWidth(of: scalar)
+
+            // Assert
+            if scalar.value == 9 { // TAB
+                #expect(width == 1, "TAB character should have width 1, got \(width)")
+            } else {
+                #expect(
+                    width == 0,
+                    "Control character U+\(String(scalar.value, radix: 16, uppercase: true)) should have width 0, got \(width)",
+                )
+            }
+        }
+    }
+
+    @Test("Combining marks have zero width")
+    func combiningMarkWidth() {
+        // Arrange - Test combining diacritical marks
+        let combiningMarks: [Unicode.Scalar] = [
+            Unicode.Scalar(0x0300)!, // COMBINING GRAVE ACCENT
+            Unicode.Scalar(0x0301)!, // COMBINING ACUTE ACCENT
+            Unicode.Scalar(0x0302)!, // COMBINING CIRCUMFLEX ACCENT
+            Unicode.Scalar(0x0308)!, // COMBINING DIAERESIS
+            Unicode.Scalar(0x030A)!, // COMBINING RING ABOVE
+        ]
+
+        for scalar in combiningMarks {
+            // Act
+            let width = Width.displayWidth(of: scalar)
+
+            // Assert
+            #expect(
+                width == 0,
+                "Combining mark U+\(String(scalar.value, radix: 16, uppercase: true)) should have width 0, got \(width)",
+            )
+        }
+    }
+
+    @Test("String with combining marks")
+    func stringWithCombiningMarks() {
+        // Arrange - Test strings with combining characters
+        let testCases: [(String, Int, String)] = [
+            ("À", 1, "A with grave accent (precomposed)"),
+            ("A\u{0300}", 1, "A + combining grave accent"),
+            ("é", 1, "e with acute accent (precomposed)"),
+            ("e\u{0301}", 1, "e + combining acute accent"),
+            ("ñ", 1, "n with tilde (precomposed)"),
+            ("n\u{0303}", 1, "n + combining tilde"),
+        ]
+
+        for (input, expectedWidth, description) in testCases {
+            // Act
+            let width = Width.displayWidth(of: input)
+
+            // Assert
+            #expect(
+                width == expectedWidth,
+                "\(description): '\(input)' should have width \(expectedWidth), got \(width)",
+            )
+        }
+    }
+
+    @Test("Whitespace characters")
+    func whitespaceCharacterWidth() {
+        // Arrange - Test various whitespace characters
+        let whitespaceChars: [(Unicode.Scalar, Int, String)] = [
+            (Unicode.Scalar(0x0020)!, 1, "SPACE"),
+            (Unicode.Scalar(0x00A0)!, 1, "NO-BREAK SPACE"),
+            (Unicode.Scalar(0x1680)!, 1, "OGHAM SPACE MARK"),
+            (Unicode.Scalar(0x2000)!, 1, "EN QUAD"),
+            (Unicode.Scalar(0x2001)!, 1, "EM QUAD"),
+            (Unicode.Scalar(0x2002)!, 1, "EN SPACE"),
+            (Unicode.Scalar(0x2003)!, 1, "EM SPACE"),
+            (Unicode.Scalar(0x2004)!, 1, "THREE-PER-EM SPACE"),
+            (Unicode.Scalar(0x2005)!, 1, "FOUR-PER-EM SPACE"),
+            (Unicode.Scalar(0x2006)!, 1, "SIX-PER-EM SPACE"),
+            (Unicode.Scalar(0x2007)!, 1, "FIGURE SPACE"),
+            (Unicode.Scalar(0x2008)!, 1, "PUNCTUATION SPACE"),
+            (Unicode.Scalar(0x2009)!, 1, "THIN SPACE"),
+            (Unicode.Scalar(0x200A)!, 1, "HAIR SPACE"),
+            (Unicode.Scalar(0x202F)!, 1, "NARROW NO-BREAK SPACE"),
+            (Unicode.Scalar(0x205F)!, 1, "MEDIUM MATHEMATICAL SPACE"),
+            (Unicode.Scalar(0x3000)!, 2, "IDEOGRAPHIC SPACE"), // Wide space
+        ]
+
+        for (scalar, expectedWidth, description) in whitespaceChars {
+            // Act
+            let width = Width.displayWidth(of: scalar)
+
+            // Assert
+            #expect(
+                width == expectedWidth,
+                "\(description) U+\(String(scalar.value, radix: 16, uppercase: true)) should have width \(expectedWidth), got \(width)",
+            )
+        }
+    }
+
+    @Test("Basic Latin characters")
+    func basicLatinCharacterWidth() {
+        // Arrange - Test Basic Latin printable range (U+0020-U+007E)
+        // Note: U+007F (DEL) is a control character and should have width 0
+        for codePoint in 0x0020 ... 0x007E {
+            guard let scalar = Unicode.Scalar(codePoint) else { continue }
+
+            // Act
+            let width = Width.displayWidth(of: scalar)
+
+            // Assert
+            #expect(
+                width == 1,
+                "Basic Latin character U+\(String(codePoint, radix: 16, uppercase: true)) should have width 1, got \(width)",
+            )
+        }
+    }
+
+    // MARK: - Performance Tests
+
+    @Test("Performance benchmark for common strings")
+    func performanceBenchmark() {
+        // Arrange - Create test strings of various types
+        let testStrings = [
+            "Hello, World!",
+            "The quick brown fox jumps over the lazy dog",
+            "ASCII text with numbers 1234567890 and symbols !@#$%^&*()",
+            "Text with accents: café, naïve, résumé, piñata",
+            "Mixed content: Hello 世界 🌍",
+            String(repeating: "A", count: 1000), // Long ASCII string
+            String(repeating: "À", count: 500), // Long string with accents
+        ]
+
+        // Act & Assert - Measure performance
+        let startTime = Date()
+
+        for _ in 0 ..< 1000 { // Run 1000 iterations
+            for testString in testStrings {
+                _ = Width.displayWidth(of: testString)
+            }
+        }
+
+        let endTime = Date()
+        let duration = endTime.timeIntervalSince(startTime)
+
+        // Performance expectation: should complete in reasonable time
+        // This is more of a smoke test than a strict performance requirement
+        #expect(duration < 1.0, "Performance test took \(duration) seconds, expected < 1.0 seconds")
+
+        print(
+            "Performance benchmark: \(testStrings.count * 1000) width calculations in \(String(format: "%.3f", duration)) seconds",
+        )
     }
 }


### PR DESCRIPTION
**What**
Provide baseline display width API backed by POSIX wcwidth/wcswidth:
- Swift wrappers for Character/Substrings
- Handle combining marks; fallback rules documented

**Why (Value/Outcome)**
Width computation underpins wrapping/slicing and border alignment.

**Acceptance Criteria**
- [x] Expected widths for ASCII, combining accents, simple emoji (baseline)
- [x] Unit tests cover: "A", "À", whitespace, control chars
- [x] Perf benchmark for common strings

**Out of Scope**
- East Asian width and emoji ZWJ sequences (covered later)

**Dependencies**
- RUNE-13 (SwiftPM structure)