### PR TITLE
Story/rune 40 use stdin stdout stderr hooks

### DIFF
--- a/Sources/RuneKit/Hooks.swift
+++ b/Sources/RuneKit/Hooks.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
 
 // Minimal hooks-style API: useEffect, requestRerender, useRef/useMemo, and useInput
 // Effects are registered during render and executed after the frame commits.
@@ -14,6 +19,9 @@ public enum HooksRuntime {
     /// App context for controlling the running application (exit/clear) from within components/effects
     @TaskLocal public static var appContext: AppContext?
 
+    /// I/O streams context bound by the runtime during build/render and effect commits
+    @TaskLocal public static var ioStreams: Streams?
+
     /// Lightweight app control surface exposed to hooks. Methods are async and actor-hopping safe.
     public struct AppContext: Sendable {
         private let _exit: @Sendable (Error?) async -> Void
@@ -28,6 +36,28 @@ public enum HooksRuntime {
         public func clear() async { await _clear() }
     }
 
+    /// Streams + metadata snapshot for hooks access. FileHandles are not Sendable; mark container unchecked.
+    public final class Streams: @unchecked Sendable {
+        public let stdin: FileHandle
+        public let stdout: FileHandle
+        public let stderr: FileHandle
+        public let stdinIsTTY: Bool
+        public let stdoutIsTTY: Bool
+        public let stderrIsTTY: Bool
+        public let stdinIsRawMode: Bool
+        public init(stdin: FileHandle, stdout: FileHandle, stderr: FileHandle,
+                    stdinIsTTY: Bool, stdoutIsTTY: Bool, stderrIsTTY: Bool,
+                    stdinIsRawMode: Bool) {
+            self.stdin = stdin
+            self.stdout = stdout
+            self.stderr = stderr
+            self.stdinIsTTY = stdinIsTTY
+            self.stdoutIsTTY = stdoutIsTTY
+            self.stderrIsTTY = stderrIsTTY
+            self.stdinIsRawMode = stdinIsRawMode
+        }
+    }
+
     // MARK: - useApp
     /// Access the application context for programmatic control from components/effects
     /// The runtime binds this during render/effect commit; calling outside a render/effect will be a no-op stub.
@@ -35,6 +65,39 @@ public enum HooksRuntime {
         if let ctx = appContext { return ctx }
         // Fallback no-op context to keep tests/app code safe when not bound
         return AppContext(exit: { _ in }, clear: { })
+    }
+
+    // MARK: - useStdin/useStdout/useStderr
+    public struct StdinInfo { public let handle: FileHandle; public let isTTY: Bool; public let isRawMode: Bool }
+    public struct StdoutInfo { public let handle: FileHandle; public let isTTY: Bool }
+    public struct StderrInfo { public let handle: FileHandle; public let isTTY: Bool }
+
+    /// Expose configured stdin stream and metadata
+    public static func useStdin() -> StdinInfo {
+        if let s = ioStreams {
+            return StdinInfo(handle: s.stdin, isTTY: s.stdinIsTTY, isRawMode: s.stdinIsRawMode)
+        }
+        // Fallback: standard input with best-effort metadata
+        let isTty = isatty(STDIN_FILENO) == 1
+        return StdinInfo(handle: FileHandle.standardInput, isTTY: isTty, isRawMode: false)
+    }
+
+    /// Expose configured stdout stream and metadata
+    public static func useStdout() -> StdoutInfo {
+        if let s = ioStreams {
+            return StdoutInfo(handle: s.stdout, isTTY: s.stdoutIsTTY)
+        }
+        let isTty = isatty(STDOUT_FILENO) == 1
+        return StdoutInfo(handle: FileHandle.standardOutput, isTTY: isTty)
+    }
+
+    /// Expose configured stderr stream and metadata
+    public static func useStderr() -> StderrInfo {
+        if let s = ioStreams {
+            return StderrInfo(handle: s.stderr, isTTY: s.stderrIsTTY)
+        }
+        let isTty = isatty(STDERR_FILENO) == 1
+        return StderrInfo(handle: FileHandle.standardError, isTTY: isTty)
     }
 
     // MARK: - Dependency token helpers

--- a/Sources/RuneKit/IOHooks.swift
+++ b/Sources/RuneKit/IOHooks.swift
@@ -1,0 +1,70 @@
+import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+/// I/O related hooks: useStdin/useStdout/useStderr and their metadata
+/// Split from Hooks.swift to uphold single responsibility and match component organization
+public enum IOHooks {
+    /// Streams + metadata snapshot for hooks access. FileHandles are not Sendable; mark container unchecked.
+    public final class Streams: @unchecked Sendable {
+        public let stdin: FileHandle
+        public let stdout: FileHandle
+        public let stderr: FileHandle
+        public let stdinIsTTY: Bool
+        public let stdoutIsTTY: Bool
+        public let stderrIsTTY: Bool
+        public let stdinIsRawMode: Bool
+        public init(stdin: FileHandle, stdout: FileHandle, stderr: FileHandle,
+                    stdinIsTTY: Bool, stdoutIsTTY: Bool, stderrIsTTY: Bool,
+                    stdinIsRawMode: Bool) {
+            self.stdin = stdin
+            self.stdout = stdout
+            self.stderr = stderr
+            self.stdinIsTTY = stdinIsTTY
+            self.stdoutIsTTY = stdoutIsTTY
+            self.stderrIsTTY = stderrIsTTY
+            self.stdinIsRawMode = stdinIsRawMode
+        }
+    }
+
+    // Public data structs returned by hooks
+    public struct StdinInfo { public let handle: FileHandle; public let isTTY: Bool; public let isRawMode: Bool }
+    public struct StdoutInfo { public let handle: FileHandle; public let isTTY: Bool }
+    public struct StderrInfo { public let handle: FileHandle; public let isTTY: Bool }
+}
+
+// Keep the user-facing hooks under HooksRuntime for a consistent API surface
+public extension HooksRuntime {
+    /// I/O streams context bound by the runtime during build/render and effect commits
+    @TaskLocal static var ioStreams: IOHooks.Streams?
+
+    /// Expose configured stdin stream and metadata
+    static func useStdin() -> IOHooks.StdinInfo {
+        if let streams = ioStreams {
+            return IOHooks.StdinInfo(handle: streams.stdin, isTTY: streams.stdinIsTTY, isRawMode: streams.stdinIsRawMode)
+        }
+        let isTty = isatty(STDIN_FILENO) == 1
+        return IOHooks.StdinInfo(handle: FileHandle.standardInput, isTTY: isTty, isRawMode: false)
+    }
+
+    /// Expose configured stdout stream and metadata
+    static func useStdout() -> IOHooks.StdoutInfo {
+        if let streams = ioStreams {
+            return IOHooks.StdoutInfo(handle: streams.stdout, isTTY: streams.stdoutIsTTY)
+        }
+        let isTty = isatty(STDOUT_FILENO) == 1
+        return IOHooks.StdoutInfo(handle: FileHandle.standardOutput, isTTY: isTty)
+    }
+
+    /// Expose configured stderr stream and metadata
+    static func useStderr() -> IOHooks.StderrInfo {
+        if let streams = ioStreams {
+            return IOHooks.StderrInfo(handle: streams.stderr, isTTY: streams.stderrIsTTY)
+        }
+        let isTty = isatty(STDERR_FILENO) == 1
+        return IOHooks.StderrInfo(handle: FileHandle.standardError, isTTY: isTty)
+    }
+}

--- a/Sources/RuneKit/Identity.swift
+++ b/Sources/RuneKit/Identity.swift
@@ -18,4 +18,3 @@ public struct Identity<T: AnyObject>: Hashable, CustomStringConvertible, @unchec
     // IdentityToken
     public var identityObject: AnyObject { object }
 }
-

--- a/Sources/RuneKit/RuneKit.swift
+++ b/Sources/RuneKit/RuneKit.swift
@@ -441,7 +441,7 @@ public actor RenderHandle {
     private var inputHandlers: [String: (active: Bool, handler: @Sendable (KeyEvent) async -> Void)] = [:]
 
     // Build a Streams snapshot for hooks (useStdin/useStdout/useStderr)
-    func streamsSnapshot() -> HooksRuntime.Streams {
+    func streamsSnapshot() -> IOHooks.Streams {
         // Safely determine FDs for standard streams without touching NSStdIO wrappers that can throw
         func fd(for h: FileHandle, fallback: Int32) -> Int32 {
             if h === FileHandle.standardInput { return STDIN_FILENO }
@@ -456,7 +456,7 @@ public actor RenderHandle {
         let stdoutIsTTY = isatty(stdoutFD) == 1
         let stderrIsTTY = isatty(stderrFD) == 1
         let isRaw = options.enableRawMode && stdinIsTTY
-        return HooksRuntime.Streams(
+        return IOHooks.Streams(
             stdin: options.stdin,
             stdout: options.stdout,
             stderr: options.stderr,

--- a/Tests/RuneKitTests/IOHooksTests.swift
+++ b/Tests/RuneKitTests/IOHooksTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+@testable import RuneKit
+
+@Suite("RUNE-40: useStdin/Stdout/Stderr hooks")
+struct IOHooksTests {
+    struct InspectView: View, ViewIdentifiable {
+        var id: String
+        var customIn: FileHandle?
+        var customOut: FileHandle?
+        var customErr: FileHandle?
+        var viewIdentity: String? { id }
+        var body: some View {
+            // Access hooks during build path
+            let stdinInfo = HooksRuntime.useStdin()
+            let stdoutInfo = HooksRuntime.useStdout()
+            let stderrInfo = HooksRuntime.useStderr()
+            // Assert basic invariants in test
+            #expect(stdinInfo.handle.fileDescriptor >= 0)
+            #expect(stdoutInfo.handle.fileDescriptor >= 0)
+            #expect(stderrInfo.handle.fileDescriptor >= 0)
+            return Text("")
+        }
+    }
+
+    @Test("Hooks surface configured custom streams")
+    func hooksReturnConfiguredStreams() async {
+        // Arrange: Set up custom pipes for all three streams
+        let inPipe = Pipe()
+        let outPipe = Pipe()
+        let errPipe = Pipe()
+        let options = RenderOptions(
+            stdout: outPipe.fileHandleForWriting,
+            stdin: inPipe.fileHandleForReading,
+            stderr: errPipe.fileHandleForWriting,
+            exitOnCtrlC: false,
+            patchConsole: false,
+            useAltScreen: false,
+            fpsCap: 30.0
+        )
+        let view = InspectView(id: "io1")
+
+        // Act
+        let handle = await render(view, options: options)
+
+        // Assert via effects: read inside an effect to ensure context is also bound there
+        await handle.rerender {
+            HooksRuntime.useEffect("check-io-hooks", deps: []) {
+                let sIn = HooksRuntime.useStdin()
+                let sOut = HooksRuntime.useStdout()
+                let sErr = HooksRuntime.useStderr()
+                #expect(sIn.handle.fileDescriptor == inPipe.fileHandleForReading.fileDescriptor)
+                #expect(sOut.handle.fileDescriptor == outPipe.fileHandleForWriting.fileDescriptor)
+                #expect(sErr.handle.fileDescriptor == errPipe.fileHandleForWriting.fileDescriptor)
+                // TTY flags are false for pipes in CI usually
+                #expect(sIn.isTTY == false || sIn.isTTY == true)
+                #expect(sOut.isTTY == false || sOut.isTTY == true)
+                #expect(sErr.isTTY == false || sErr.isTTY == true)
+                // Raw mode metadata reflects options + TTY; on pipes it's false
+                #expect(sIn.isRawMode == false)
+                return nil
+            }
+            return Text("")
+        }
+
+        await handle.unmount()
+        await handle.waitUntilExit()
+    }
+
+    @Test("Default environment streams are exposed with metadata")
+    func defaultEnvironmentStreams() async {
+        let handle = await render(Text("noop"), options: RenderOptions(exitOnCtrlC: false, patchConsole: false, useAltScreen: false, enableRawMode: false, enableBracketedPaste: false, fpsCap: 30.0))
+        await handle.rerender {
+            HooksRuntime.useEffect("defaults-io-hooks", deps: []) {
+                let sIn = HooksRuntime.useStdin()
+                let sOut = HooksRuntime.useStdout()
+                let sErr = HooksRuntime.useStderr()
+                // The file descriptors should match standard handles when not overridden (can't guarantee under test runner),
+                // but we can at least assert they are valid FDs and that metadata fields exist.
+                #expect(sIn.handle.fileDescriptor >= 0)
+                #expect(sOut.handle.fileDescriptor >= 0)
+                #expect(sErr.handle.fileDescriptor >= 0)
+                _ = sIn.isTTY; _ = sOut.isTTY; _ = sErr.isTTY
+                _ = sIn.isRawMode
+                return nil
+            }
+            return Text("")
+        }
+        await handle.unmount()
+        await handle.waitUntilExit()
+    }
+}
+

--- a/docs/public/io-hooks.md
+++ b/docs/public/io-hooks.md
@@ -1,0 +1,43 @@
+# RuneKit I/O Hooks (RUNE-40)
+
+RuneKit exposes hooks to access the configured I/O streams and basic metadata from within your components and effects.
+
+- HooksRuntime.useStdin() -> (handle, isTTY, isRawMode)
+- HooksRuntime.useStdout() -> (handle, isTTY)
+- HooksRuntime.useStderr() -> (handle, isTTY)
+
+These values respect the streams passed via render(options). If you supply custom FileHandles for stdin/stdout/stderr, the hooks will surface those exact handles.
+
+Metadata:
+- isTTY is computed using isatty(fd)
+- isRawMode is true when RenderOptions.enableRawMode is enabled and stdin is a TTY
+
+Example:
+
+```swift
+struct IOExample: View {
+    var body: some View {
+        HooksRuntime.useEffect("log-io", deps: []) {
+            let stdinInfo = HooksRuntime.useStdin()
+            let stdoutInfo = HooksRuntime.useStdout()
+            let stderrInfo = HooksRuntime.useStderr()
+            // You can inspect and optionally write to these handles if needed
+            // e.g., write a message directly to stderr
+            let msg = "Using TTY? \(stdoutInfo.isTTY)\n"
+            if let data = msg.data(using: .utf8) {
+                stderrInfo.handle.write(data)
+            }
+            return nil
+        }
+        return Text("I/O hooks demo")
+    }
+}
+
+// Configure custom streams
+let outPipe = Pipe()
+let options = RenderOptions(stdout: outPipe.fileHandleForWriting,
+                            exitOnCtrlC: false, patchConsole: false,
+                            useAltScreen: false, fpsCap: 30.0)
+let handle = await render(IOExample(), options: options)
+```
+


### PR DESCRIPTION
**What**
Expose configured streams and metadata (isTTY, isRawMode); respect render options.

**Why (Value/Outcome)**
Advanced apps can inspect/override I/O streams as in Ink.

**Acceptance Criteria**
- [ ] Hooks return correct stream objects/metadata.
- [ ] Custom streams via render options are accessible.
- [ ] Docs example included.

**Out of Scope**
- Cross-process redirection.

**Dependencies**
RUNE-24; RUNE-36

**Size**
S
