### PR TITLE
[RUNE-41] Story: Focus registry + useFocus/useFocusManager

### DIFF
--- a/Sources/RuneComponents/Box.swift
+++ b/Sources/RuneComponents/Box.swift
@@ -204,6 +204,41 @@ public struct Box: Component {
         self.children = Array(children)
     }
 
+    /// Public convenience initializer to construct a Box from an array of Components
+    /// Useful for bridging higher-level View collections into Component children.
+    public init(childrenArray: [Component]) {
+        self.init(
+            border: .none,
+            borderColor: nil,
+            backgroundColor: nil,
+            flexDirection: .column,
+            justifyContent: .flexStart,
+            alignItems: .stretch,
+            alignSelf: .auto,
+            width: .auto,
+            height: .auto,
+            paddingTop: 0,
+            paddingRight: 0,
+            paddingBottom: 0,
+            paddingLeft: 0,
+            marginTop: 0,
+            marginRight: 0,
+            marginBottom: 0,
+            marginLeft: 0,
+            rowGap: 0,
+            columnGap: 0,
+            flexGrow: 0,
+            flexShrink: 1,
+            flexBasis: .auto,
+            flexWrap: .noWrap,
+            minWidth: .auto,
+            maxWidth: .auto,
+            minHeight: .auto,
+            maxHeight: .auto,
+            childrenArray: childrenArray
+        )
+    }
+
     /// Internal initializer for array of children (used by helper functions)
     init(
         border: BorderStyle = .none,

--- a/Sources/RuneKit/AppExit.swift
+++ b/Sources/RuneKit/AppExit.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-/// Types that provide an exit code for application termination
-public protocol AppExitCodeProviding {
-    var exitCode: Int32 { get }
-}
-
+/// Deprecated shim retained for compatibility after moving AppExitCodeProviding
+@available(*, deprecated, message: "AppExitCodeProviding has moved; import RuneKit and use the protocol from AppExitCodeProviding.swift")
+public enum AppExit {}

--- a/Sources/RuneKit/AppExitCodeProviding.swift
+++ b/Sources/RuneKit/AppExitCodeProviding.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// Types that provide an exit code for application termination
+public protocol AppExitCodeProviding {
+    var exitCode: Int32 { get }
+}

--- a/Sources/RuneKit/EffectCollectorBox.swift
+++ b/Sources/RuneKit/EffectCollectorBox.swift
@@ -3,16 +3,20 @@ import Foundation
 /// Thread-safe collector used during render to gather effect registrations
 /// Exists as a separate file/type to be Sendable-capture friendly in @Sendable closures.
 public final class EffectCollectorBox: @unchecked Sendable {
-    private var items: [(id: String, deps: String?, effect: @Sendable () async -> (() -> Void)?)] = []
+    public struct Entry: Sendable {
+        public let id: String
+        public let deps: String?
+        public let effect: @Sendable () async -> (() -> Void)?
+    }
+    private var items: [Entry] = []
     private let lock = NSLock()
     public init() {}
     public func add(id: String, deps: String?, effect: @Sendable @escaping () async -> (() -> Void)?) {
         lock.lock(); defer { lock.unlock() }
-        items.append((id: id, deps: deps, effect: effect))
+        items.append(Entry(id: id, deps: deps, effect: effect))
     }
-    public func snapshot() -> [(id: String, deps: String?, effect: @Sendable () async -> (() -> Void)?)] {
+    public func snapshot() -> [Entry] {
         lock.lock(); defer { lock.unlock() }
         return items
     }
 }
-

--- a/Sources/RuneKit/HooksFocusCollector.swift
+++ b/Sources/RuneKit/HooksFocusCollector.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+// Thread-safe append-only collector optimized for use from callbacks that may run on different contexts.
+// In our usage, focusRecorder is invoked during render on the same task, but to satisfy the compiler's
+// concurrency checks, we avoid mutating a captured Array from a TaskLocal closure by providing an object.
+final class HooksFocusCollector: @unchecked Sendable {
+    private var storage: [String] = []
+    private let lock = NSLock()
+
+    func record(_ path: String) {
+        lock.lock(); defer { lock.unlock() }
+        storage.append(path)
+    }
+
+    func snapshot() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        return storage
+    }
+}

--- a/Sources/RuneKit/InputManager.swift
+++ b/Sources/RuneKit/InputManager.swift
@@ -127,7 +127,9 @@ public actor InputManager {
         if enableRawMode { await enableRawModeIfTTY() }
         if enableBracketedPaste { writeControl("\u{001B}[?2004h") }
 
-        if isATTY(input.fileDescriptor) == 1 {
+        // In CI/test harness we don't need a background read loop; tests inject via process(bytes:).
+        // Only spawn the loop when reading is actually desired (raw or bracketed paste) AND stdin is a TTY.
+        if (enableRawMode || enableBracketedPaste) && isATTY(input.fileDescriptor) == 1 {
             readTask = Task.detached { [weak self] in
                 await self?.readLoop()
             }

--- a/Sources/RuneKit/InputManager.swift
+++ b/Sources/RuneKit/InputManager.swift
@@ -19,6 +19,7 @@ public enum KeyKind: Equatable, Sendable {
     case up, down, left, right
     case home, end, pageUp, pageDown
     case function(Int) // F1..F12
+    case tab
 }
 
 /// Key events recognized by RuneKit input system
@@ -35,6 +36,9 @@ public enum KeyEvent: Equatable, Sendable {
     case key(kind: KeyKind, modifiers: KeyModifiers)
 
     // Bracketed paste
+    /// Convenience alias for a plain Tab key event
+    public static var tabKey: KeyEvent { .key(kind: .tab, modifiers: []) }
+
     case paste(String)
 }
 
@@ -64,6 +68,40 @@ public actor InputManager {
 
     // Background read task
     private var readTask: Task<Void, Never>?
+
+    // Lookup tables to keep mapping logic simple (lower cyclomatic complexity)
+    private static let arrowKindMap: [UInt8: KeyKind] = [
+        0x41: .up,    // A
+        0x42: .down,  // B
+        0x43: .right, // C
+        0x44: .left   // D
+    ]
+
+    private static let tildeKindMap: [Int: KeyKind] = [
+        5: .pageUp,
+        6: .pageDown,
+        15: .function(5),
+        17: .function(6),
+        18: .function(7),
+        19: .function(8),
+        20: .function(9),
+        21: .function(10),
+        23: .function(11),
+        24: .function(12)
+    ]
+
+    private static let ss3Map: [UInt8: KeyEvent] = [
+        0x41: .arrowUp,
+        0x42: .arrowDown,
+        0x43: .arrowRight,
+        0x44: .arrowLeft,
+        0x48: .key(kind: .home, modifiers: []),
+        0x46: .key(kind: .end, modifiers: []),
+        0x50: .key(kind: .function(1), modifiers: []),
+        0x51: .key(kind: .function(2), modifiers: []),
+        0x52: .key(kind: .function(3), modifiers: []),
+        0x53: .key(kind: .function(4), modifiers: [])
+    ]
 
     public init(
         input: FileHandle,
@@ -118,8 +156,8 @@ public actor InputManager {
 
     private func emit(_ event: KeyEvent) async { await handler?(event) }
 
-    private func writeControl(_ s: String) {
-        if let data = s.data(using: .utf8) { controlOut.write(data) }
+    private func writeControl(_ control: String) {
+        if let data = control.data(using: .utf8) { controlOut.write(data) }
     }
 
     private func isATTY(_ fd: Int32) -> Int32 { isatty(fd) }
@@ -127,18 +165,18 @@ public actor InputManager {
     private func enableRawModeIfTTY() async {
         let fd = input.fileDescriptor
         guard isATTY(fd) == 1 else { return }
-        var t = termios()
-        if tcgetattr(fd, &t) == 0 {
-            originalTermios = t
-            cfmakeraw(&t)
+        var term = termios()
+        if tcgetattr(fd, &term) == 0 {
+            originalTermios = term
+            cfmakeraw(&term)
             // Set VMIN/VTIME: non-blocking-ish read with 100ms timeout
-            withUnsafeMutablePointer(to: &t.c_cc) { p in
-                p.withMemoryRebound(to: cc_t.self, capacity: Int(NCCS)) { ccp in
+            withUnsafeMutablePointer(to: &term.c_cc) { ctrlArrayPtr in
+                ctrlArrayPtr.withMemoryRebound(to: cc_t.self, capacity: Int(NCCS)) { ccp in
                     ccp[Int(VMIN)] = 0
                     ccp[Int(VTIME)] = 1
                 }
             }
-            _ = tcsetattr(fd, TCSAFLUSH, &t)
+            _ = tcsetattr(fd, TCSAFLUSH, &term)
         }
     }
 
@@ -154,13 +192,13 @@ public actor InputManager {
         var buf = [UInt8](repeating: 0, count: 1024)
         while !Task.isCancelled {
             #if os(Linux)
-            let n = Glibc.read(fd, &buf, buf.count)
+            let bytesRead = Glibc.read(fd, &buf, buf.count)
             #else
-            let n = Darwin.read(fd, &buf, buf.count)
+            let bytesRead = Darwin.read(fd, &buf, buf.count)
             #endif
-            if n > 0 {
-                await process(bytes: Array(buf[0..<Int(n)]))
-            } else if n == 0 {
+            if bytesRead > 0 {
+                await process(bytes: Array(buf[0..<Int(bytesRead)]))
+            } else if bytesRead == 0 {
                 break // EOF
             } else {
                 // sleep briefly to avoid spin on EAGAIN/interrupt
@@ -174,6 +212,7 @@ public actor InputManager {
         while !buffer.isEmpty {
             if await handleBracketedPasteIfNeeded() { continue }
             if await handleImmediateControlIfNeeded() { continue }
+            if await handleTabIfNeeded() { continue }
             if await handlePasteStartIfNeeded() { continue }
             if await handleEscapedSequencesIfNeeded() { continue }
             // Fallback: if ESC may start a sequence, wait for more; otherwise consume one byte
@@ -189,6 +228,8 @@ public actor InputManager {
                 let endStart = endRange.lowerBound
                 pasteBuffer.append(contentsOf: buffer[..<endStart])
                 buffer.removeFirst(endRange.upperBound)
+                // Intentionally allow lossy decoding for paste content which may contain arbitrary bytes
+                // swiftlint:disable:next optional_data_string_conversion
                 let text = String(decoding: pasteBuffer, as: UTF8.self)
                 pasteBuffer.removeAll(keepingCapacity: true)
                 isInBracketedPaste = false
@@ -203,8 +244,17 @@ public actor InputManager {
         return false
     }
 
+    private func handleTabIfNeeded() async -> Bool {
+        if let first = buffer.first, first == 0x09 { // HT (Tab)
+            buffer.removeFirst()
+            await emit(.key(kind: .tab, modifiers: []))
+            return true
+        }
+        return false
+    }
+
     private func handleImmediateControlIfNeeded() async -> Bool {
-        if let first = buffer.first, (first == 0x03 || first == 0x04) {
+        if let first = buffer.first, first == 0x03 || first == 0x04 {
             let ctrl = first == 0x03 ? KeyEvent.ctrlC : KeyEvent.ctrlD
             buffer.removeFirst()
             await emit(ctrl)
@@ -266,7 +316,9 @@ public actor InputManager {
             if (65...90).contains(Int(ch)) || ch == 0x7E { // 'A'..'Z' or '~'
                 // Parse parameters (if any) between '[' and final
                 let paramsBytes = bytes[2..<i]
-                let params = String(decoding: paramsBytes, as: UTF8.self)
+                // swiftlint:disable:next optional_data_string_conversion
+                let paramsString = String(decoding: paramsBytes, as: UTF8.self)
+                let params = paramsString
                     .split(separator: ";")
                     .compactMap { Int($0) }
                 let final = ch
@@ -283,14 +335,17 @@ public actor InputManager {
 
     private func mapCSI(params: [Int], final: UInt8) -> KeyEvent? {
         switch final {
+        case 0x5A: // CSI Z is often sent for Shift+Tab
+            // Map to tab with shift modifier via KeyKind.tab
+            return .key(kind: .tab, modifiers: [.shift])
         case 0x41, 0x42, 0x43, 0x44: // Arrows A..D
             return mapArrow(final: final, params: params)
         case 0x48: // H Home
-            let m = params.count >= 2 ? modsFrom(code: params.last!) : []
-            return .key(kind: .home, modifiers: m)
+            let mods = params.count >= 2 ? modsFrom(code: params.last!) : []
+            return .key(kind: .home, modifiers: mods)
         case 0x46: // F End
-            let m = params.count >= 2 ? modsFrom(code: params.last!) : []
-            return .key(kind: .end, modifiers: m)
+            let mods = params.count >= 2 ? modsFrom(code: params.last!) : []
+            return .key(kind: .end, modifiers: mods)
         case 0x7E: // ~ family
             return mapTildeFamily(params: params)
         default:
@@ -300,25 +355,22 @@ public actor InputManager {
 
     private func modsFrom(code: Int) -> KeyModifiers {
         // xterm: 1+shift(1)+alt(2)+ctrl(4)
-        let m = code - 1
-        var out: KeyModifiers = []
-        if (m & 1) != 0 { out.insert(.shift) }
-        if (m & 2) != 0 { out.insert(.alt) }
-        if (m & 4) != 0 { out.insert(.ctrl) }
-        return out
+        let mask = code - 1
+        var mods: KeyModifiers = []
+        if (mask & 1) != 0 { mods.insert(.shift) }
+        if (mask & 2) != 0 { mods.insert(.alt) }
+        if (mask & 4) != 0 { mods.insert(.ctrl) }
+        return mods
     }
 
     private func mapArrow(final: UInt8, params: [Int]) -> KeyEvent? {
+        // With modifiers (CSI 1;5A etc.)
         if let last = params.last, params.count >= 2 {
+            guard let kind = Self.arrowKindMap[final] else { return nil }
             let mods = modsFrom(code: last)
-            switch final {
-            case 0x41: return .key(kind: .up, modifiers: mods)
-            case 0x42: return .key(kind: .down, modifiers: mods)
-            case 0x43: return .key(kind: .right, modifiers: mods)
-            case 0x44: return .key(kind: .left, modifiers: mods)
-            default: return nil
-            }
+            return .key(kind: kind, modifiers: mods)
         }
+        // Legacy arrows without modifiers
         switch final {
         case 0x41: return .arrowUp
         case 0x42: return .arrowDown
@@ -330,20 +382,9 @@ public actor InputManager {
 
     private func mapTildeFamily(params: [Int]) -> KeyEvent? {
         guard let code = params.first else { return nil }
-        let m = params.count >= 2 ? modsFrom(code: params.last!) : []
-        switch code {
-        case 5: return .key(kind: .pageUp, modifiers: m)
-        case 6: return .key(kind: .pageDown, modifiers: m)
-        case 15: return .key(kind: .function(5), modifiers: m)
-        case 17: return .key(kind: .function(6), modifiers: m)
-        case 18: return .key(kind: .function(7), modifiers: m)
-        case 19: return .key(kind: .function(8), modifiers: m)
-        case 20: return .key(kind: .function(9), modifiers: m)
-        case 21: return .key(kind: .function(10), modifiers: m)
-        case 23: return .key(kind: .function(11), modifiers: m)
-        case 24: return .key(kind: .function(12), modifiers: m)
-        default: return nil
-        }
+        let mods = params.count >= 2 ? modsFrom(code: params.last!) : []
+        guard let kind = Self.tildeKindMap[code] else { return nil }
+        return .key(kind: kind, modifiers: mods)
     }
 
     // Parse SS3 sequences like ESC O A, ESC O P (F1)
@@ -351,19 +392,10 @@ public actor InputManager {
         guard bytes.count >= 3 else { return nil }
         let final = bytes[2]
         let consumed = 3
-        switch final {
-        case 0x41: return (consumed, .arrowUp)  // Up
-        case 0x42: return (consumed, .arrowDown)
-        case 0x43: return (consumed, .arrowRight)
-        case 0x44: return (consumed, .arrowLeft)
-        case 0x48: return (consumed, .key(kind: .home, modifiers: [])) // OH sometimes used
-        case 0x46: return (consumed, .key(kind: .end, modifiers: []))  // OF sometimes used
-        case 0x50: return (consumed, .key(kind: .function(1), modifiers: [])) // OP
-        case 0x51: return (consumed, .key(kind: .function(2), modifiers: [])) // OQ
-        case 0x52: return (consumed, .key(kind: .function(3), modifiers: [])) // OR
-        case 0x53: return (consumed, .key(kind: .function(4), modifiers: [])) // OS
-        default: return (consumed, nil)
+        if let ev = Self.ss3Map[final] {
+            return (consumed, ev)
         }
+        return (consumed, nil)
     }
 
     // Find CSI ESC [ <param> starting at any position; return range [start,end)
@@ -380,4 +412,3 @@ public actor InputManager {
         return nil
     }
 }
-

--- a/Sources/RuneRenderer/TerminalRenderer.swift
+++ b/Sources/RuneRenderer/TerminalRenderer.swift
@@ -357,8 +357,6 @@ public actor TerminalRenderer {
         previousLineCount = grid.height
         stats.linesChanged = grid.height
         stats.totalLines = grid.height
-
-
         return stats
     }
 

--- a/Sources/RuneUnicode/Width.swift
+++ b/Sources/RuneUnicode/Width.swift
@@ -32,15 +32,18 @@ public enum Width {
         if !string.contains("\u{001B}[") {
             // Fast path A: if the string is pure ASCII, count bytes directly without grapheme iteration
             var allASCII = true
-            for b in string.utf8 { if b >= 0x80 { allASCII = false; break } }
+            for byte in string.utf8 where byte >= 0x80 { allASCII = false; break }
             if allASCII {
-                var w = 0
-                for b in string.utf8 {
-                    if b >= 0x20 && b <= 0x7E { w &+= 1 }
-                    else if b == 0x09 { w &+= 1 } // TAB
+                var width = 0
+                for byte in string.utf8 {
+                    if byte >= 0x20 && byte <= 0x7E {
+                        width &+= 1
+                    } else if byte == 0x09 {
+                        width &+= 1 // TAB
+                    }
                     // other controls contribute 0
                 }
-                return w
+                return width
             }
             var totalWidth = 0
             for cluster in string {
@@ -83,10 +86,9 @@ public enum Width {
                 hasCombining = true
                 // Combining characters don't add to width
                 continue
-            } else {
-                // Non-combining character
-                baseWidth += displayWidthEnhanced(of: scalar)
             }
+            // Non-combining character
+            baseWidth += displayWidthEnhanced(of: scalar)
         }
 
         // If we had combining characters, return the base width

--- a/Tests/RuneKitTests/FocusRegistryTests.swift
+++ b/Tests/RuneKitTests/FocusRegistryTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+import RuneKit
+
+@Suite("RUNE-41: Focus registry + useFocus/useFocusManager")
+struct FocusRegistryTests {
+    actor Sink {
+        private(set) var events: [KeyEvent] = []
+        func add(_ e: KeyEvent) { events.append(e) }
+        func all() -> [KeyEvent] { events }
+        func clear() { events.removeAll() }
+    }
+
+    struct FocusableView: View, ViewIdentifiable {
+        var id: String
+        var sink: Sink
+        var viewIdentity: String? { id }
+        var body: some View {
+            // Mark this component as focusable and render an indicator when focused
+            let isFocused = HooksRuntime.useFocus()
+            HooksRuntime.useInput({ event in
+                await sink.add(event)
+            }, isActive: true)
+            return Text(isFocused ? "[\(id)]" : id)
+        }
+    }
+
+    @Test("Tab cycles focus among focusable elements and gates input to focused one")
+    func tabCyclesFocusAndGatesInput() async {
+        let sinkA = Sink(); let sinkB = Sink(); let sinkC = Sink()
+        let options = RenderOptions(exitOnCtrlC: false, patchConsole: false, useAltScreen: false, fpsCap: 60)
+        let handle = await render(Box(children:
+            FocusableView(id: "A", sink: sinkA),
+            FocusableView(id: "B", sink: sinkB),
+            FocusableView(id: "C", sink: sinkC)
+        ), options: options)
+
+        // After initial mount, focus should default to first focusable (A).
+        // Send an arrow key; only A should receive initially.
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x41]) // Up
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(await sinkA.all().contains(.arrowUp))
+        #expect(await sinkB.all().isEmpty)
+        #expect(await sinkC.all().isEmpty)
+
+        // Press Tab (0x09) -> focus moves to B
+        await handle.testingProcessInput(bytes: [0x09])
+        // Send Down; only B should receive now
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x42])
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(await sinkB.all().contains(.arrowDown))
+        #expect(await sinkA.all().count == 1) // still just the first event
+        #expect(await sinkC.all().isEmpty)
+
+        // Shift+Tab (often ESC [ Z) -> focus moves back to A
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x5A])
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x43]) // Right
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(await sinkA.all().contains(.arrowRight))
+        #expect(await sinkC.all().isEmpty)
+
+        await handle.unmount()
+        await handle.waitUntilExit()
+    }
+
+    struct GlobalListenerView: View, ViewIdentifiable {
+        var id: String
+        var sink: Sink
+        var viewIdentity: String? { id }
+        var body: some View {
+            // Do NOT mark focusable; register global input listener (opt-out of focus gating)
+            HooksRuntime.useInput({ event in await sink.add(event) }, isActive: true, requiresFocus: false)
+            return Text(id)
+        }
+    }
+
+    @Test("Global input handlers receive events regardless of focus; others are gated")
+    func globalOptOutReceivesRegardlessOfFocus() async {
+        let sf = Sink(); let sg = Sink()
+        let options = RenderOptions(exitOnCtrlC: false, patchConsole: false, useAltScreen: false, fpsCap: 60)
+        let handle = await render(Box(children:
+            FocusableView(id: "F", sink: sf),
+            GlobalListenerView(id: "G", sink: sg)
+        ), options: options)
+
+        // Initially focus on F; send Up. Both F (focused) and G (global) should receive.
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x41])
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(await sf.all().contains(.arrowUp))
+        #expect(await sg.all().contains(.arrowUp))
+
+        // Shift+Tab to cycle (with only one focusable, it should stay on F). Send Right.
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x5A])
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x43])
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(await sf.all().contains(.arrowRight))
+        #expect(await sg.all().contains(.arrowRight))
+
+        await handle.unmount()
+        await handle.waitUntilExit()
+    }
+
+    struct PlainInputView: View, ViewIdentifiable {
+        var id: String
+        var sink: Sink
+        var viewIdentity: String? { id }
+        var body: some View {
+            // No focusable elements registered anywhere in the tree
+            HooksRuntime.useInput({ event in await sink.add(event) }, isActive: true)
+            return Text(id)
+        }
+    }
+
+    @Test("When no focusables are registered, useInput remains broadcast to all active handlers (back-compat)")
+    func noFocusablesBackCompatBroadcast() async {
+        let s1 = Sink(); let s2 = Sink()
+        let options = RenderOptions(exitOnCtrlC: false, patchConsole: false, useAltScreen: false, fpsCap: 60)
+        let handle = await render(Box(children:
+            PlainInputView(id: "P1", sink: s1),
+            PlainInputView(id: "P2", sink: s2)
+        ), options: options)
+
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x41])
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(await s1.all().contains(.arrowUp))
+        #expect(await s2.all().contains(.arrowUp))
+
+        await handle.unmount()
+        await handle.waitUntilExit()
+    }
+}
+

--- a/Tests/RuneKitTests/UseFocusManagerHookIntegrationTests.swift
+++ b/Tests/RuneKitTests/UseFocusManagerHookIntegrationTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+import RuneKit
+
+@Suite("RUNE-41: useFocusManager hook integration")
+struct UseFocusManagerHookIntegrationTests {
+    actor Sink {
+        private(set) var events: [KeyEvent] = []
+        func add(_ e: KeyEvent) { events.append(e) }
+        func all() -> [KeyEvent] { events }
+        func clear() { events.removeAll() }
+    }
+
+    struct FocusableView: View, ViewIdentifiable {
+        var id: String
+        var sink: Sink
+        var viewIdentity: String? { id }
+        var body: some View {
+            let isFocused = HooksRuntime.useFocus()
+            let mgr = HooksRuntime.useFocusManager()
+            HooksRuntime.useInput({ event in
+                // On Tab, move focus forward programmatically using the hook
+                if event == .tabKey { await mgr.next() }
+                await sink.add(event)
+            }, isActive: true)
+            return Text(isFocused ? "[\(id)]" : id)
+        }
+    }
+
+    @Test("Tab advances focus via useFocusManager hook")
+    func tabAdvancesFocus() async {
+        let sA = Sink(); let sB = Sink(); let sC = Sink()
+        let handle = await render(Box(children:
+            FocusableView(id: "A", sink: sA),
+            FocusableView(id: "B", sink: sB),
+            FocusableView(id: "C", sink: sC)
+        ))
+
+        // Initially A focused; send Tab to trigger mgr.next() from inside handler
+        await handle.testingProcessInput(bytes: [0x09]) // Tab
+        try? await Task.sleep(for: .milliseconds(30))
+
+        // Now B should receive the next event
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x42]) // Down
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(await sB.all().contains(.arrowDown))
+
+        await handle.unmount()
+        await handle.waitUntilExit()
+    }
+}
+

--- a/Tests/RuneKitTests/UseFocusManagerHookTests.swift
+++ b/Tests/RuneKitTests/UseFocusManagerHookTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Testing
+import RuneKit
+
+@Suite("RUNE-41: useFocusManager hook")
+struct UseFocusManagerHookTests {
+    actor Sink {
+        private(set) var events: [KeyEvent] = []
+        func add(_ e: KeyEvent) { events.append(e) }
+        func all() -> [KeyEvent] { events }
+        func clear() { events.removeAll() }
+    }
+
+    struct FocusableView: View, ViewIdentifiable {
+        var id: String
+        var sink: Sink
+        var viewIdentity: String? { id }
+        var body: some View {
+            let isFocused = HooksRuntime.useFocus()
+            HooksRuntime.useInput({ event in await sink.add(event) }, isActive: true)
+            return Text(isFocused ? "[\(id)]" : id)
+        }
+    }
+
+    @Test("Programmatic next/previous cycles focus and gates input")
+    func programmaticCycling() async {
+        let sinkA = Sink(); let sinkB = Sink(); let sinkC = Sink()
+        let options = RenderOptions(exitOnCtrlC: false, patchConsole: false, useAltScreen: false, fpsCap: 60)
+        let handle = await render(Box(children:
+            FocusableView(id: "A", sink: sinkA),
+            FocusableView(id: "B", sink: sinkB),
+            FocusableView(id: "C", sink: sinkC)
+        ), options: options)
+
+        // Initially A focused. Send Up; only A receives.
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x41])
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(await sinkA.all().contains(.arrowUp))
+        #expect(await sinkB.all().isEmpty)
+        #expect(await sinkC.all().isEmpty)
+        await sinkA.clear(); await sinkB.clear(); await sinkC.clear()
+
+        // Programmatically move to next (B)
+        await handle.focusNext()
+        try? await Task.sleep(for: .milliseconds(20))
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x42]) // Down
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(await sinkB.all().contains(.arrowDown))
+        #expect(await sinkA.all().isEmpty)
+        #expect(await sinkC.all().isEmpty)
+
+        // Move previous back to A
+        await handle.focusPrevious()
+        try? await Task.sleep(for: .milliseconds(20))
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x43]) // Right
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(await sinkA.all().contains(.arrowRight))
+
+        await handle.unmount()
+        await handle.waitUntilExit()
+    }
+
+    @Test("Direct focus by id/path works")
+    func directFocusByIdAndPath() async {
+        let sinkA = Sink(); let sinkB = Sink(); let sinkC = Sink()
+        let options = RenderOptions(exitOnCtrlC: false, patchConsole: false, useAltScreen: false, fpsCap: 60)
+        let handle = await render(Box(children:
+            FocusableView(id: "A", sink: sinkA),
+            FocusableView(id: "B", sink: sinkB),
+            FocusableView(id: "C", sink: sinkC)
+        ), options: options)
+
+        // Sanity: initial focused path should be A
+        if let fp = await handle.currentFocusedPath() {
+            #expect(fp.hasSuffix("/A"))
+        } else {
+            #expect(Bool(false), "Expected a focused path initially")
+        }
+
+        // Focus by id("C")
+        let ok1 = await handle.focus(id: "C")
+        #expect(ok1 == true)
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x44]) // Left
+        try? await Task.sleep(for: .milliseconds(30))
+        #expect(await sinkC.all().contains(.arrowLeft))
+        await sinkA.clear(); await sinkB.clear(); await sinkC.clear()
+
+        // Focus by an existing path substring that should match C's identity path
+        if let path = await handle.currentFocusedPath() {
+            let ok2 = await handle.focus(path: path)
+            #expect(ok2 == true)
+            await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x41]) // Up
+            try? await Task.sleep(for: .milliseconds(30))
+            #expect(await sinkC.all().contains(.arrowUp))
+        } else {
+            #expect(Bool(false), "Expected a focused path to be available")
+        }
+
+        await handle.unmount()
+        await handle.waitUntilExit()
+    }
+
+    @Test("No-focusables broadcast remains unaffected by manager")
+    func noFocusablesBroadcastUnaffected() async {
+        let s1 = Sink(); let s2 = Sink()
+        let options = RenderOptions(exitOnCtrlC: false, patchConsole: false, useAltScreen: false, fpsCap: 60)
+        let handle = await render(Box(children:
+            // These do not call useFocus(); no focusables will be registered
+            Text("X"),
+            Text("Y")
+        ), options: options)
+
+        let mgr = HooksRuntime.useFocusManager()
+        // Manager operations should be no-ops; ensure broadcast still happens
+        await mgr.next()
+        let ok = await mgr.focus(id: "anything")
+        #expect(ok == false)
+
+        // Register two global listeners that do not require focus
+        struct Global: View, ViewIdentifiable { var id: String; var viewIdentity: String? { id }; var body: some View { HooksRuntime.useInput({ _ in }, isActive: true, requiresFocus: false); return Text(id) } }
+        await handle.rerender(Box(children: Global(id: "g1"), Global(id: "g2")))
+        await handle.testingProcessInput(bytes: [0x1B, 0x5B, 0x41])
+        // Not asserting delivery here; covered by FocusRegistryTests no-focusables test. We just check no crash.
+
+        await handle.unmount()
+        await handle.waitUntilExit()
+    }
+}
+


### PR DESCRIPTION
**What**
Register focusable components; focusNext/Previous; integrate with useInput so only focused element receives keys unless opted out.

**Why (Value/Outcome)**
Predictable keyboard navigation across components.

**Acceptance Criteria**
- [x] Tab/Shift+Tab cycles focus among elements.
- [x] Only focused component receives input by default.
- [x] Demo with multiple buttons shows focus indicator and routing.

**Out of Scope**
- Mouse focus; persistence across restarts.

**Dependencies**
RUNE-38

**Size**
M