### PR TITLE
[RUNE-42] Story: Last-column autowrap guard

### DIFF
--- a/Sources/RuneRenderer/RenderConfiguration.swift
+++ b/Sources/RuneRenderer/RenderConfiguration.swift
@@ -73,6 +73,9 @@ public struct RenderConfiguration: Sendable {
     /// Feature flag: allow public injection of OutputEncoder/CursorManager
     public let enablePluggableIO: Bool
 
+    /// Whether to disable DECAWM autowrap during render to prevent last-column spill
+    public let disableAutowrapDuringRender: Bool
+
     // MARK: - Initialization
 
     public init(
@@ -84,6 +87,7 @@ public struct RenderConfiguration: Sendable {
         useAlternateScreen: Bool = false,
         enableConsoleCapture: Bool = false,
         enablePluggableIO: Bool = false,
+        disableAutowrapDuringRender: Bool = false
     ) {
         self.optimizationMode = optimizationMode
         self.performance = performance
@@ -93,6 +97,7 @@ public struct RenderConfiguration: Sendable {
         self.useAlternateScreen = useAlternateScreen
         self.enableConsoleCapture = enableConsoleCapture
         self.enablePluggableIO = enablePluggableIO
+        self.disableAutowrapDuringRender = disableAutowrapDuringRender
     }
 
     /// Backward-compatible initializer without the pluggable IO flag
@@ -114,6 +119,7 @@ public struct RenderConfiguration: Sendable {
             useAlternateScreen: useAlternateScreen,
             enableConsoleCapture: enableConsoleCapture,
             enablePluggableIO: false,
+            disableAutowrapDuringRender: false
         )
     }
 

--- a/Sources/RuneRenderer/TerminalRenderer.swift
+++ b/Sources/RuneRenderer/TerminalRenderer.swift
@@ -112,6 +112,10 @@ public actor TerminalRenderer {
             await hideCursor()
         }
 
+        // Optionally disable autowrap to prevent last-column spill
+        let shouldDisableAutowrap = configuration?.disableAutowrapDuringRender ?? false
+        if shouldDisableAutowrap { await disableAutowrapIfNeeded() }
+
         // Use the provided strategy regardless of screen buffer; strategy determiner
         // and higher-level policies decide between full redraw, delta, or scroll-optimized.
         stats.strategy = strategy
@@ -137,6 +141,9 @@ public actor TerminalRenderer {
             await showCursor()
         }
 
+        // Re-enable autowrap if we disabled it
+        if shouldDisableAutowrap { await enableAutowrapIfNeeded() }
+
         return stats
     }
 
@@ -156,6 +163,10 @@ public actor TerminalRenderer {
         if shouldRestoreCursor {
             await hideCursor()
         }
+
+        // Optionally disable autowrap to prevent last-column spill
+        let shouldDisableAutowrap = configuration?.disableAutowrapDuringRender ?? false
+        if shouldDisableAutowrap { await disableAutowrapIfNeeded() }
 
         // Determine rendering strategy
         let strategy: RenderingStrategy = if forceFullRedraw {
@@ -195,6 +206,9 @@ public actor TerminalRenderer {
             await showCursor()
         }
 
+        // Re-enable autowrap if we disabled it
+        if shouldDisableAutowrap { await enableAutowrapIfNeeded() }
+
         return stats
     }
 
@@ -210,6 +224,9 @@ public actor TerminalRenderer {
         // Always ensure cursor is visible after clearing, regardless of current state
         await writeSequence("\u{001B}[?25h")
         cursorHidden = false
+
+        // Restore autowrap if we had disabled it
+        await enableAutowrapIfNeeded()
     }
 
     /// Hide the cursor
@@ -250,6 +267,8 @@ public actor TerminalRenderer {
         if cursorHidden {
             await showCursor()
         }
+        // Restore autowrap if we had disabled it
+        await enableAutowrapIfNeeded()
 
         // Reset state
         currentGrid = nil

--- a/Tests/RuneRendererTests/AutowrapGuardTests.swift
+++ b/Tests/RuneRendererTests/AutowrapGuardTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import RuneRenderer
+
+struct AutowrapGuardTests {
+    @Test("Grid omits wide cluster at EOL (CJK fullwidth)")
+    func gridOmitsWideAtEOL_CJK() {
+        // "表" is width 2; preceding ASCII is width 1
+        let line = "A表"
+        let grid = TerminalGrid(lines: [line], width: 2)
+        guard let row = grid.getRow(0) else { return #expect(Bool(false), "row 0 should exist") }
+        #expect(row.count == 2)
+        // Last cell should not be the wide char; should be empty padding
+        #expect(row[1].content != "表")
+        #expect(row[1].content == " ")
+    }
+
+    @Test("Grid omits wide cluster at EOL (emoji)")
+    func gridOmitsWideAtEOL_Emoji() {
+        let line = "x👍" // x(1) + 👍(2) => total 3; width=2 should drop 👍
+        let grid = TerminalGrid(lines: [line], width: 2)
+        guard let row = grid.getRow(0) else { return #expect(Bool(false), "row 0 should exist") }
+        #expect(row.count == 2)
+        #expect(row[0].content == "x")
+        #expect(row[1].content == " ")
+    }
+
+    @Test("Grid omits wide cluster at EOL (fullwidth punctuation)")
+    func gridOmitsWideAtEOL_FullwidthPunct() {
+        let line = "x，" // x(1) + ，(2)
+        let grid = TerminalGrid(lines: [line], width: 2)
+        guard let row = grid.getRow(0) else { return #expect(Bool(false), "row 0 should exist") }
+        #expect(row.count == 2)
+        #expect(row[0].content == "x")
+        #expect(row[1].content == " ")
+    }
+
+    @Test("DECAWM toggles off/on around full redraw when enabled")
+    func decawmTogglesFullRedraw() async {
+        let pipe = Pipe(); defer { pipe.fileHandleForReading.closeFile() }
+        let cfg = RenderConfiguration(disableAutowrapDuringRender: true)
+        let renderer = TerminalRenderer(output: pipe.fileHandleForWriting, encoder: nil, cursor: nil, configuration: cfg)
+        let grid = TerminalGrid(width: 4, height: 2)
+        _ = await renderer.render(grid, strategy: .fullRedraw)
+        pipe.fileHandleForWriting.closeFile()
+        let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        #expect(out.contains("\u{001B}[?7l"), "Should disable autowrap at start of render")
+        #expect(out.contains("\u{001B}[?7h"), "Should re-enable autowrap at end of render")
+    }
+
+    @Test("DECAWM toggles off/on around delta update when enabled")
+    func decawmTogglesDelta() async {
+        let pipe = Pipe(); defer { pipe.fileHandleForReading.closeFile() }
+        let cfg = RenderConfiguration(disableAutowrapDuringRender: true)
+        let renderer = TerminalRenderer(output: pipe.fileHandleForWriting, encoder: nil, cursor: nil, configuration: cfg)
+        var g1 = TerminalGrid(width: 3, height: 2)
+        var g2 = g1
+        g2.setCell(at: 0, column: 0, to: TerminalCell(content: "X"))
+        _ = await renderer.render(g1, strategy: .fullRedraw)
+        _ = await renderer.render(g2, strategy: .deltaUpdate, previousGrid: g1)
+        pipe.fileHandleForWriting.closeFile()
+        let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        // Expect at least one disable/enable pair across the renders
+        #expect(out.contains("\u{001B}[?7l"))
+        #expect(out.contains("\u{001B}[?7h"))
+    }
+}
+


### PR DESCRIPTION
**What**
Pre-wrap logic to avoid last-column spill; optional DECAWM off (`ESC[?7l`) with fallback; restore on exit.

**Why (Value/Outcome)**
Terminals auto-wrap at last column; guard required for precise redraws.

**Acceptance Criteria**
- [x] Wide clusters at EOL never spill.
- [x] DECAWM-off path works; fallback documented.
- [x] Unit tests for boundary cases with emoji/fullwidth punctuation.

**Out of Scope**
- Terminal-specific quirk detection beyond guard.

**Dependencies**
RUNE-18; RUNE-19

**Size**
S
